### PR TITLE
Add Hyperliquid ManagedBasisStrategy pipeline

### DIFF
--- a/examples/managed_basis_strategy/mb_pipeline.py
+++ b/examples/managed_basis_strategy/mb_pipeline.py
@@ -1,0 +1,71 @@
+import os
+import warnings
+
+import numpy as np
+from datetime import datetime
+from sklearn.model_selection import ParameterGrid
+
+from fractal.core.pipeline import (
+    DefaultPipeline, MLFlowConfig, ExperimentConfig)
+
+from mb_strategy import HyperliquidBasis, build_observations
+
+warnings.filterwarnings('ignore')
+
+
+def build_grid():
+    raw_grid = ParameterGrid({
+        'MIN_LEVERAGE': np.arange(1, 1.9, 0.5).tolist(),
+        'TARGET_LEVERAGE': np.arange(1, 2.4, 0.5).tolist(),
+        'MAX_LEVERAGE': np.arange(1, 2.9, 0.5).tolist(),
+        'EXECUTION_COST': [0.004],
+        'INITIAL_BALANCE': [1_000_000]
+    })
+
+    valid_grid = [
+        params for params in raw_grid
+        if round(params['MIN_LEVERAGE'], 1) < round(params['TARGET_LEVERAGE'], 1) < round(params['MAX_LEVERAGE'], 1)
+    ]
+    return valid_grid
+
+
+if __name__ == '__main__':
+    ticker: str = 'VIRTUAL'
+    start_time = datetime(2024, 1, 1)
+    end_time = datetime(2025, 1, 1)
+    fidelity = 'day'
+    experiment_name = f'T_mb_hl_virtual_{fidelity}_{ticker}_{start_time.strftime("%Y-%m-%d")}_{end_time.strftime("%Y-%m-%d")}'
+
+# Define MLFlow and Experiment configurations
+
+    mlflow_uri = os.getenv('MLFLOW_URI')
+    aws_key = os.getenv('AWS_ACCESS_KEY_ID')
+    aws_secret = os.getenv('AWS_SECRET_ACCESS_KEY')
+
+    if not mlflow_uri:
+        raise ValueError("MLFLOW_URI isn't set.")
+
+    if not aws_key or not aws_secret:
+        warnings.warn("AWS_ACCESS_KEY_ID или AWS_SECRET_ACCESS_KEY are not set", RuntimeWarning)
+
+    mlflow_config: MLFlowConfig = MLFlowConfig(
+        mlflow_uri=mlflow_uri,
+        experiment_name=experiment_name,
+        aws_access_key_id=aws_key,
+        aws_secret_access_key=aws_secret,
+    )
+
+    observations = build_observations(ticker, start_time, end_time, fidelity=fidelity)
+    assert len(observations) > 0
+    experiment_config: ExperimentConfig = ExperimentConfig(
+        strategy_type=HyperliquidBasis,
+        backtest_observations=observations,
+        window_size=24,
+        params_grid=build_grid(),
+        debug=True,
+    )
+    pipeline: DefaultPipeline = DefaultPipeline(
+        experiment_config=experiment_config,
+        mlflow_config=mlflow_config
+    )
+    pipeline.run()

--- a/examples/managed_basis_strategy/mb_strategy.py
+++ b/examples/managed_basis_strategy/mb_strategy.py
@@ -40,10 +40,10 @@ def get_observations(
         start_time: datetime = None, end_time: datetime = None
     ) -> List[Observation]:
     """
-    Get observations from the pool and price data for the TauResetStrategy.
+    Get observations from the pool and price data for the ManagedBasisStrategy.
 
     Returns:
-        List[Observation]: The observation list for TauResetStrategy.
+        List[Observation]: The observation list for ManagedBasisStrategy.
     """
     observations_df: pd.DataFrame = price_data.join(rate_data)
     observations_df = observations_df.dropna()
@@ -68,7 +68,7 @@ def build_observations(
         ticker: str, start_time: datetime = None, end_time: datetime = None, fidelity: str = 'hour',
     ) -> List[Observation]:
     """
-    Build observations for the TauResetStrategy from the given start and end time.
+    Build observations for the ManagedBasisStrategy from the given start and end time.
     """
     rate_data: RateHistory = HyperliquidFundingRatesLoader(
         ticker, loader_type=LoaderType.CSV).read(with_run=True)

--- a/fractal/core/entities/hyperliquid.py
+++ b/fractal/core/entities/hyperliquid.py
@@ -125,7 +125,7 @@ class HyperliquidEntity(BaseHedgeEntity):
 
             maintenance_margin: float = (entry_price * position_size) / (2 * leverage)
 
-            if self._internal_state.collateral - amount_in_notional < maintenance_margin:
+            if self.balance - amount_in_notional < maintenance_margin:
                 raise HyperliquidEntityException(
                     f"Not enough maintenance margin after withdraw: {maintenance_margin} < "
                     f"{self.balance - amount_in_notional}.")


### PR DESCRIPTION
This pull request includes significant updates to the `examples/managed_basis_strategy` module and a minor fix in the `fractal/core/entities/hyperliquid.py` file. The most important changes include the addition of a new pipeline script, renaming and updating strategy references, and a correction in the margin calculation logic.

### New pipeline script:
* [`examples/managed_basis_strategy/mb_pipeline.py`](diffhunk://#diff-78afbc14f5f9926dd525234475eebc4a2ebb622a78ec5772db9fc98c200b71f0R1-R71): Added a new script to define and run a pipeline for the Managed Basis Strategy, including configurations for MLFlow and experiment parameters.

### Strategy updates:
* [`examples/managed_basis_strategy/mb_strategy.py`](diffhunk://#diff-4d080b163336d43327e63a43293ec7ff81d095c41f1567adf06287f5dc7734dfL43-R46): Renamed from `examples/managed_basis_strategy.py/mb_strategy.py` and updated references from `TauResetStrategy` to `ManagedBasisStrategy` in the `get_observations` and `build_observations` functions. [[1]](diffhunk://#diff-4d080b163336d43327e63a43293ec7ff81d095c41f1567adf06287f5dc7734dfL43-R46) [[2]](diffhunk://#diff-4d080b163336d43327e63a43293ec7ff81d095c41f1567adf06287f5dc7734dfL71-R71)

### Margin calculation fix:
* [`fractal/core/entities/hyperliquid.py`](diffhunk://#diff-509c1160f3440f852b81c07f8f213897b2d5763b248c27a4baf274bc2c39de8dL128-R128): Fixed the margin calculation logic in the `action_withdraw` method by changing the reference from `self._internal_state.collateral` to `self.balance`.