### PR TITLE
Fix LP token minting logic in UniswapV2LPEntity and update liquidity/fees calculations

### DIFF
--- a/fractal/core/entities/uniswap_v2_lp.py
+++ b/fractal/core/entities/uniswap_v2_lp.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 
-import numpy as np
-
 from fractal.core.base.entity import EntityException
 from fractal.core.entities.pool import BasePoolEntity
 
@@ -38,6 +36,7 @@ class UniswapV2LPInternalState:
         liquidity (float): The position liquidity.
         cash (float): The cash balance.
     """
+
     token0_amount: float = 0.0
     token1_amount: float = 0.0
     price_init: float = 0.0
@@ -56,6 +55,7 @@ class UniswapV2LPConfig:
         token1_decimals (int): The token1 decimals.
         trading_fee (float): The trading fee.
     """
+
     fees_rate: float = 0.005
     token0_decimals: int = 18
     token1_decimals: int = 18
@@ -68,6 +68,7 @@ class UniswapV2LPEntity(BasePoolEntity):
 
     It maintains exact 50-50 position of token0 and token1 in the pool.
     """
+
     def __init__(self, config: UniswapV2LPConfig, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.is_position = False
@@ -100,6 +101,30 @@ class UniswapV2LPEntity(BasePoolEntity):
             raise EntityException("Insufficient funds to withdraw.")
         self._internal_state.cash -= amount_in_notional
 
+    def _mint_lp_tokens(self, x: float, y: float) -> float:
+        """
+        Mint LP tokens based on the amount of token0 and token1 in the pool.
+
+        Args:
+            x (float): The amount of token0 in the pool.
+            y (float): The amount of token1 in the pool.
+
+        Returns:
+            float: The amount of LP tokens minted.
+        """
+        total_lp = self._global_state.liquidity
+        reserve0 = self._global_state.tvl / 2
+
+        if self._global_state.price == 0:
+            raise EntityException("Price is 0.")
+
+        reserve1 = reserve0 / self._global_state.price
+
+        if reserve0 == 0 or reserve1 == 0:
+            raise EntityException("Reserve is 0.")
+
+        return min((x / reserve0) * total_lp, (y / reserve1) * total_lp)
+
     def action_open_position(self, amount_in_notional: float) -> None:
         """
         Open a position in the LP entity.
@@ -114,13 +139,13 @@ class UniswapV2LPEntity(BasePoolEntity):
         self.is_position = True
         self._internal_state.cash -= amount_in_notional
         amount_in_position = amount_in_notional * (1 - self.trading_fee)
+
         x = amount_in_position / 2
         y = amount_in_position / 2 / self._global_state.price
         self._internal_state.token0_amount = x
         self._internal_state.token1_amount = y
         self._internal_state.price_init = self._global_state.price
-        self._internal_state.liquidity = (amount_in_position ** 2) *\
-                                         (10 ** (self.token0_decimals / self.token1_decimals))
+        self._internal_state.liquidity = self._mint_lp_tokens(x, y)
 
     def action_close_position(self):
         """
@@ -128,7 +153,11 @@ class UniswapV2LPEntity(BasePoolEntity):
         """
         if not self.is_position:
             raise EntityException("No position to close.")
-        cash = self.balance * (1 - self.trading_fee)
+
+        lp_value = self._internal_state.token0_amount + self._internal_state.token1_amount * self._global_state.price
+
+        cash = (lp_value * (1 - self.trading_fee)) + self._internal_state.cash
+
         self.is_position = False
         self._internal_state = UniswapV2LPInternalState(cash=cash)
 
@@ -142,10 +171,21 @@ class UniswapV2LPEntity(BasePoolEntity):
             state (UniswapV2LPGlobalState): The state of the pool.
         """
         self._global_state = state
-        p = state.price
+
         if self.is_position:
-            self._internal_state.token0_amount = np.sqrt(self._internal_state.liquidity * p)
-            self._internal_state.token1_amount = np.sqrt(self._internal_state.liquidity / p)
+
+            if self._global_state.price == 0:
+                raise EntityException("Price is 0.")
+            if self._global_state.liquidity == 0:
+                raise EntityException("Pool liquidity is 0.")
+
+            share = self._internal_state.liquidity / self._global_state.liquidity
+            reserve0 = self._global_state.tvl / 2
+            reserve1 = reserve0 / self._global_state.price
+
+            self._internal_state.token0_amount = share * reserve0
+            self._internal_state.token1_amount = share * reserve1
+
         self._internal_state.cash += self.calculate_fees()
 
     @property

--- a/tests/core/test_uniswap_v2_lp.py
+++ b/tests/core/test_uniswap_v2_lp.py
@@ -1,14 +1,13 @@
 import pytest
-
-from fractal.core.entities.uniswap_v2_lp import (UniswapV2LPConfig,
-                                                 UniswapV2LPEntity,
-                                                 UniswapV2LPGlobalState)
+from fractal.core.entities.uniswap_v2_lp import UniswapV2LPConfig, UniswapV2LPEntity, UniswapV2LPGlobalState
 
 
 @pytest.fixture
 def uniswap_lp_entity():
-    config = UniswapV2LPConfig(fees_rate=0.005, token0_decimals=18, token1_decimals=18, trading_fee=0.003)
-    return UniswapV2LPEntity(config=config)
+    config = UniswapV2LPConfig(fees_rate=0.005, token0_decimals=6, token1_decimals=18, trading_fee=0.003)
+    entity = UniswapV2LPEntity(config=config)
+    entity.update_state(UniswapV2LPGlobalState(tvl=10_000, liquidity=10_000, fees=0, price=1000, volume=0))
+    return entity
 
 
 @pytest.mark.core
@@ -26,30 +25,28 @@ def test_action_withdraw(uniswap_lp_entity):
 
 @pytest.mark.core
 def test_action_open_position(uniswap_lp_entity):
-    uniswap_lp_entity.update_state(UniswapV2LPGlobalState(price=1000))
     uniswap_lp_entity.action_deposit(1000)
     uniswap_lp_entity.action_open_position(500)
-    assert uniswap_lp_entity.balance == 998.5
-    assert uniswap_lp_entity.is_position == True
-    assert uniswap_lp_entity._internal_state.token0_amount == 249.25
-    assert uniswap_lp_entity._internal_state.token1_amount == 0.24925
+    assert round(uniswap_lp_entity.balance, 6) == 998.5
+    assert uniswap_lp_entity.is_position is True
+    assert round(uniswap_lp_entity._internal_state.token0_amount, 6) == 249.25
+    assert round(uniswap_lp_entity._internal_state.token1_amount, 6) == 0.24925
     assert uniswap_lp_entity._internal_state.price_init == 1000
-    assert uniswap_lp_entity._internal_state.liquidity == 2485022.5
+    assert uniswap_lp_entity._internal_state.liquidity == 498.5
 
 
 @pytest.mark.core
 def test_action_close_position(uniswap_lp_entity):
-    uniswap_lp_entity.update_state(UniswapV2LPGlobalState(price=1000))
     uniswap_lp_entity.action_deposit(1000)
     uniswap_lp_entity.action_open_position(500)
     uniswap_lp_entity.action_close_position()
-    assert uniswap_lp_entity.balance == 995.5045
-    assert uniswap_lp_entity.is_position == False
+    assert uniswap_lp_entity.is_position is False
+    assert round(uniswap_lp_entity.balance, 6) == 997.0045
 
 
 @pytest.mark.core
 def test_update_state(uniswap_lp_entity):
-    state = UniswapV2LPGlobalState(price=1000)
+    state = UniswapV2LPGlobalState(tvl=20_000, liquidity=20_000, price=2000, fees=50, volume=0)
     uniswap_lp_entity.update_state(state)
     assert uniswap_lp_entity._global_state == state
 
@@ -62,8 +59,15 @@ def test_balance(uniswap_lp_entity):
 
 @pytest.mark.core
 def test_calculate_fees(uniswap_lp_entity):
-    uniswap_lp_entity.update_state(UniswapV2LPGlobalState(price=1000, liquidity=1000000, fees=100))
+
     uniswap_lp_entity.action_deposit(1000)
     uniswap_lp_entity.action_open_position(500)
-    fees = uniswap_lp_entity.calculate_fees()
-    assert fees == 248.50225
+    updated_state = UniswapV2LPGlobalState(tvl=10_000, liquidity=10_000, price=1000, fees=100, volume=0)
+    uniswap_lp_entity.update_state(updated_state)
+    fees_earned = uniswap_lp_entity.calculate_fees()
+    assert fees_earned >= 0
+    assert fees_earned <= updated_state.fees
+    assert round(fees_earned, 8) == 4.985
+    share = uniswap_lp_entity._internal_state.liquidity / updated_state.liquidity
+    expected_fees = share * updated_state.fees
+    assert round(fees_earned, 8) == round(expected_fees, 8)


### PR DESCRIPTION
### Summary

This PR fixes the LP token minting logic in `UniswapV2LPEntity` to ensure correct handling of liquidity provisioning. It also updates related fee and liquidity calculations to align with expected Uniswap V2 behavior.

### Changes

- Updated minting logic for LP tokens
- Corrected fee and liquidity math in `UniswapV2LPEntity`
- Adjusted unit tests to reflect the new logic and edge cases

### Notes

- All tests pass locally (`pytest`)
- Based on the `dev` branch, as requested by the maintainers
- Please let me know if any refactoring or extra test coverage is needed

### Checklist

- [x] PR targets `dev` branch
- [x] Clear title and description
- [x] All tests pass
- [x] Review requested
