### PR TITLE
Fix uniswap v3 fees model

### DIFF
--- a/fractal/core/entities/models/uniswap_v3_fees.py
+++ b/fractal/core/entities/models/uniswap_v3_fees.py
@@ -1,60 +1,69 @@
-Q96 = 2 ** 96
+Q96 = 1 << 96  # same as 2**96, but as an int
 
-
-def expand_decimals(amount: float, decimals: int) -> float:
-    return amount * (10 ** decimals)
-
+def expand_decimals(amount: float, decimals: int) -> int:
+    # scale token amount into its integer representation
+    return int(amount * 10**decimals)
 
 def get_liquidity_for_amount0(
-        sqrt_ratio_a_x96: float, sqrt_ratio_b_x96: float,
-        amount0: float
-) -> float:
-    # amount0 * (sqrt(upper) * sqrt(lower)) / (sqrt(upper) - sqrt(lower))
-    inter = sqrt_ratio_b_x96 * sqrt_ratio_a_x96 / Q96
-    return amount0 * inter / (sqrt_ratio_b_x96 - sqrt_ratio_a_x96)
-
+        sqrt_ratio_a_x96: int, sqrt_ratio_b_x96: int,
+        amount0: int
+) -> int:
+    # amount0 * (sqrt(b)*sqrt(a)/Q96) / (sqrt(b) - sqrt(a))
+    # all inputs are Q96-scaled ints
+    inter = (sqrt_ratio_a_x96 * sqrt_ratio_b_x96) >> 96
+    return amount0 * inter // (sqrt_ratio_b_x96 - sqrt_ratio_a_x96)
 
 def get_liquidity_for_amount1(
-        sqrt_ratio_a_x96: float, sqrt_ratio_b_x96: float,
-        amount1: float
-) -> float:
-    # amount1 / (sqrt(upper) - sqrt(lower))
-    return amount1 * Q96 / (sqrt_ratio_b_x96 - sqrt_ratio_a_x96)
+        sqrt_ratio_a_x96: int, sqrt_ratio_b_x96: int,
+        amount1: int
+) -> int:
+    # amount1 * Q96 / (sqrt(b) - sqrt(a))
+    return amount1 * Q96 // (sqrt_ratio_b_x96 - sqrt_ratio_a_x96)
 
-
-def get_sqrt_price_x96(price: float, token0_decimal: int, token1_decimal: int) -> float:
-    token0 = expand_decimals(price, token0_decimal)
-    token1 = expand_decimals(1, token1_decimal)
-    return ((token0 / token1)**0.5) * Q96
-
+def get_sqrt_price_x96(
+        price: float, token0_decimal: int, token1_decimal: int
+) -> int:
+    """
+    Compute sqrt(price) in Q96 fixed-point.
+    price is token1 per token0.
+    """
+    # scale price to fixed-point
+    scaled = (price * 10**token1_decimal) / 10**token0_decimal
+    return int(scaled**0.5 * Q96)
 
 def get_liquidity_delta(
         P: float, lower_price: float, upper_price: float,
         amount0: float, amount1: float,
         token0_decimal: int, token1_decimal: int
-) -> float:
-    amt0 = expand_decimals(amount0, token1_decimal)
-    amt1 = expand_decimals(amount1, token0_decimal)
+) -> int:
+    # first, expand amounts correctly
+    amt0 = expand_decimals(amount0, token0_decimal)
+    amt1 = expand_decimals(amount1, token1_decimal)
 
-    sqrt_ratio_x96 = get_sqrt_price_x96(P, token0_decimal, token1_decimal)
+    sqrt_ratio_x96   = get_sqrt_price_x96(P,           token0_decimal, token1_decimal)
     sqrt_ratio_a_x96 = get_sqrt_price_x96(lower_price, token0_decimal, token1_decimal)
     sqrt_ratio_b_x96 = get_sqrt_price_x96(upper_price, token0_decimal, token1_decimal)
+
+    if sqrt_ratio_b_x96 <= sqrt_ratio_a_x96:
+        raise ValueError("upper_price must be greater than lower_price")
 
     if sqrt_ratio_x96 <= sqrt_ratio_a_x96:
         liquidity = get_liquidity_for_amount0(sqrt_ratio_a_x96, sqrt_ratio_b_x96, amt0)
     elif sqrt_ratio_x96 < sqrt_ratio_b_x96:
-        liquidity0 = get_liquidity_for_amount0(sqrt_ratio_x96, sqrt_ratio_b_x96, amt0)
-        liquidity1 = get_liquidity_for_amount1(sqrt_ratio_a_x96, sqrt_ratio_x96, amt1)
+        liquidity0 = get_liquidity_for_amount0(sqrt_ratio_x96,   sqrt_ratio_b_x96, amt0)
+        liquidity1 = get_liquidity_for_amount1(sqrt_ratio_a_x96, sqrt_ratio_x96,   amt1)
         liquidity = min(liquidity0, liquidity1)
     else:
         liquidity = get_liquidity_for_amount1(sqrt_ratio_a_x96, sqrt_ratio_b_x96, amt1)
 
     return liquidity
 
-
 def estimate_fee(
-        liquidity_delta: float, liquidity: float,
+        liquidity_delta: int, liquidity: int,
         fees: float,
 ) -> float:
-    liquidity_percentage = liquidity_delta / (liquidity + liquidity_delta)
-    return fees * liquidity_percentage
+    """
+    Pro-rate collected swap fees by the LP’s share of total liquidity.
+    fees must be the total fees collected from swaps.
+    """
+    return fees * (liquidity_delta / (liquidity + liquidity_delta))


### PR DESCRIPTION
## Code Changelog
- `expand_decimals` now returns an int and uses the correct token decimals.
- All `Q96` math is done in integers, with bit-shifts for the √b·√a product.
- We check that `upper_price > lower_price`.



## Checklist:
- [x] PR to `dev` branch
- [x] Label of PR
- [x] Review is requested up
- [x] tests created & runned
