### PR TITLE
.github: issue templates, dependabot, label sync and public docs improvement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @xboringwozniak
+*       @0xBoringWozniak @likeblood

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,64 @@
+---
+name: Bug report
+about: Something works incorrectly or crashes — not how to use the library.
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!--
+Thanks for the report! Keep the title short and descriptive (under 70 chars).
+Detail goes in the body below. The clearer the repro, the faster the fix.
+-->
+
+## Summary
+
+<!-- One or two sentences: what's broken and where. -->
+
+## Repro
+
+<!--
+A minimal, runnable Python snippet that triggers the bug. Trim away
+everything not directly required to reproduce. If it depends on a CSV /
+real-data fixture, paste a short slice instead of attaching the file.
+-->
+
+```python
+```
+
+## Expected vs actual
+
+- **Expected:**
+- **Actual:**
+
+<!-- If a stack trace is involved, paste it inside a fenced block. -->
+
+```
+```
+
+## Affected level
+
+<!--
+Same 6-level taxonomy used on the PR template. Tick all that apply.
+-->
+
+- [ ] **entity** — `fractal/core/entities/` (Aave, Hyperliquid, Uniswap, stETH, GMX, simple/*)
+- [ ] **strategy** — `fractal/strategies/` (BasisTrading, HyperliquidBasis, TauReset)
+- [ ] **loaders** — `fractal/loaders/` (Binance, Hyperliquid, Aave, GMX, TheGraph, sims)
+- [ ] **core** — `fractal/core/base/`, `fractal/core/pipeline.py` (Action / Observation / BaseStrategy / MLflow pipeline)
+- [ ] **infra** — `setup.py`, `Makefile`, `.github/`, `scripts/`, `docs/`, pre-commit, pyproject
+- [ ] **tests** — `tests/` (core / loaders / mlflow_tests)
+
+## Environment
+
+- `fractal-defi` version: <!-- e.g. 1.3.0; check with `pip show fractal-defi` -->
+- Python version: <!-- `python --version` -->
+- OS: <!-- macOS 14, Ubuntu 22.04, etc. -->
+- Install method: <!-- pip from PyPI / pip from source / editable -->
+
+## Notes
+
+<!--
+Anything else worth knowing: when you first saw it, last known good
+version, which test/script surfaced it, related issues.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# When the user clicks "New issue", offer the structured templates
+# (bug / feature) and these contact links — but no "Open a blank
+# issue" escape hatch. Forces the right form to be picked up front,
+# which keeps the issue list scannable.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Architecture & internals
+    url: https://github.com/Logarithm-Labs/fractal-defi/blob/main/ARCHITECTURE.md
+    about: Entity-as-state-machine semantics, InternalState/GlobalState split, pipeline internals.
+
+  - name: Contributing & release flow
+    url: https://github.com/Logarithm-Labs/fractal-defi/blob/main/CONTRIBUTING.md
+    about: Setup, branching (dev → main), testing pyramid, pre-commit / CI pipeline. Read before opening a PR.
+
+  - name: Examples
+    url: https://github.com/Logarithm-Labs/fractal-defi/tree/main/examples
+    about: quick_start, basis, tau_reset, holder, agentic_trader — runnable references for the public API.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,67 @@
+---
+name: Feature request
+about: Propose a new entity, strategy, loader, or framework capability.
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+<!--
+Thanks for the proposal! Lead with the use case, not the implementation.
+Keep the title short and descriptive (under 70 chars).
+-->
+
+## Use case
+
+<!--
+What are you trying to do? Describe the research / strategy / data
+problem in plain terms before discussing solutions. A concrete scenario
+("I want to backtest X across Y under Z conditions") is much more
+useful than "we should add ABC".
+-->
+
+## Proposed API or behavior
+
+<!--
+Sketch the surface — class names, method signatures, expected inputs
+and outputs. Pseudocode is fine; doesn't need to compile.
+-->
+
+```python
+```
+
+## Alternatives considered
+
+<!-- What did you try first? Why didn't an existing primitive cover it? -->
+
+## Affected level
+
+<!--
+Same 6-level taxonomy used on the PR template. Tick all that apply.
+-->
+
+- [ ] **entity** — `fractal/core/entities/` (new protocol, new action, new state field)
+- [ ] **strategy** — `fractal/strategies/` (new strategy, new hyperparam shape)
+- [ ] **loaders** — `fractal/loaders/` (new venue / endpoint / cache layer / simulator)
+- [ ] **core** — `fractal/core/base/`, `fractal/core/pipeline.py` (new contract surface, MLflow pipeline change)
+- [ ] **infra** — `setup.py`, `Makefile`, `.github/`, `scripts/`, `docs/`, pre-commit, pyproject
+- [ ] **tests** — `tests/` (new harness, new fixture, new test layer)
+
+## Backwards compatibility
+
+<!--
+Would this change existing public types, method signatures, or behavior?
+If yes, what migration path do users have? If you'd hide it behind a
+new flag/class, say so.
+-->
+
+- [ ] Pure addition — no existing API affected
+- [ ] Additive but touches existing types (new optional param, new method)
+- [ ] Breaking — requires migration
+
+## Notes
+
+<!--
+Links to papers, prior art (other DeFi libraries), related issues, or
+prototypes you've already drafted. Skip if none.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,13 +9,18 @@ Detailed context goes in the body below.
 
 ## What changed
 
-<!-- Bullet list, one line per item. Group by area if helpful. -->
+<!--
+Tick the level(s) this PR touches and add a one-line note on each.
+Levels mirror the repo's mental model — same set on bug_report.md
+and feature_request.md, so reviewers can filter consistently.
+-->
 
-- [ ] entities:
-- [ ] strategies:
-- [ ] loaders:
-- [ ] pipeline / MLflow:
-- [ ] tests / docs:
+- [ ] **entity** — `fractal/core/entities/` (Aave, Hyperliquid, Uniswap, stETH, GMX, simple/*):
+- [ ] **strategy** — `fractal/strategies/` (BasisTrading, HyperliquidBasis, TauReset):
+- [ ] **loaders** — `fractal/loaders/` (Binance, Hyperliquid, Aave, GMX, TheGraph, sims):
+- [ ] **core** — `fractal/core/base/`, `fractal/core/pipeline.py` (Action / Observation / BaseStrategy / MLflow pipeline):
+- [ ] **infra** — `setup.py`, `Makefile`, `.github/`, `scripts/`, `docs/`, pre-commit, pyproject:
+- [ ] **tests** — `tests/` (core / loaders / mlflow_tests):
 
 ## Test plan
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,110 @@
+# Dependabot — automated version-bump PRs.
+#
+# Every update opens a PR against ``dev`` (per the gitflow rule that
+# only ``dev`` is ever merged into ``main``), labelled and grouped
+# so the PR list stays scannable.
+#
+# Cadence:
+#   weekly  → things we want to keep current (runtime libs, GH Actions)
+#   monthly → lower-volatility surfaces (example sandboxes, Docker
+#             base images) — less noise, still catches CVEs
+#
+# Grouping: bumps for related ecosystems land in a SINGLE PR rather
+# than 5 separate ones. Major-version bumps still split out (default
+# behavior) so a breaking change doesn't ride along quietly.
+#
+# Updating this file: ``dependabot.yml`` is validated by GitHub on
+# push; mistakes show up under Insights → Dependency graph →
+# Dependabot. The schema lives at:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+
+updates:
+  # ─── Python deps (setup.py runtime + [dev] extras) ──────────────
+  # Dependabot reads ``setup.py``'s ``install_requires`` and
+  # ``extras_require``; it does NOT distinguish [dev] from runtime,
+  # so we split them into groups by name patterns instead.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "dev"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "infra"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      runtime:
+        # Things end users get when they ``pip install fractal-defi``.
+        # Bumps here can break consumers — review carefully.
+        patterns:
+          - "mlflow"
+          - "pandas"
+          - "numpy"
+          - "loguru"
+          - "requests"
+          - "scikit-learn"
+      dev:
+        # Dev tooling under [dev] extra — only contributors see it.
+        # Safer to batch and merge.
+        patterns:
+          - "pytest*"
+          - "pylint"
+          - "flake8"
+          - "isort"
+          - "pre-commit"
+          - "sphinx*"
+
+  # Agentic-trader example has its own ``requirements.txt`` (LLM
+  # SDKs etc.) — orthogonal to the core library, monthly is enough.
+  - package-ecosystem: "pip"
+    directory: "/examples/agentic_trader"
+    schedule:
+      interval: "monthly"
+    target-branch: "dev"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "infra"
+    commit-message:
+      prefix: "deps(agentic_trader)"
+
+  # ─── GitHub Actions ─────────────────────────────────────────────
+  # Bumps actions/checkout, setup-python, cache, upload-artifact, etc.
+  # All into one PR per week — these almost always go in together.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "dev"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "infra"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # ─── Docker (MLflow harness base image) ─────────────────────────
+  # Picks up new ``python:3.x`` / ``mlflow`` base-image versions in
+  # ``tests/mlflow_tests/Dockerfile``. Monthly cadence — the harness
+  # only runs in the e2e job, low blast radius.
+  - package-ecosystem: "docker"
+    directory: "/tests/mlflow_tests"
+    schedule:
+      interval: "monthly"
+    target-branch: "dev"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "tests"
+    commit-message:
+      prefix: "deps(docker)"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,116 @@
+# Canonical GitHub label set for the repo.
+#
+# Format is the one consumed by ``EndBug/label-sync`` and
+# ``crazy-max/ghaction-github-labeler``. If you don't run a sync
+# action yet, this file is documentation — apply it manually via:
+#
+#     # one-shot bulk apply (requires gh CLI authenticated):
+#     yq -r '.[] | "gh label create \"\(.name)\" --color \(.color) --description \"\(.description)\" --force"' \
+#         .github/labels.yml | bash
+#
+# Label families:
+#   * type:   bug / enhancement / documentation / question
+#             — what kind of issue or PR (mutually exclusive in practice)
+#   * area:   the 6-level repo taxonomy (entity / strategy / loaders /
+#             core / infra / tests) — same set the issue + PR templates
+#             surface; multiple can apply
+#   * status: needs-triage, help wanted, good first issue, blocked, …
+#   * meta:   dependencies, breaking-change, performance, security,
+#             release — orthogonal cross-cuts
+
+# ─── type ───────────────────────────────────────────────────────
+- name: "bug"
+  color: "d73a4a"
+  description: "Something works incorrectly or crashes."
+
+- name: "enhancement"
+  color: "a2eeef"
+  description: "New entity / strategy / loader / capability."
+
+- name: "documentation"
+  color: "0075ca"
+  description: "Docs, docstrings, README, ARCHITECTURE, examples copy."
+
+- name: "question"
+  color: "d876e3"
+  description: "Usage question — consider Discussions instead."
+
+# ─── area (6-level taxonomy from issue + PR templates) ──────────
+# Single muted color across the family so they read as a group.
+- name: "area: entity"
+  color: "bfd4f2"
+  description: "fractal/core/entities/ — Aave, Hyperliquid, Uniswap, stETH, GMX, simple/*."
+
+- name: "area: strategy"
+  color: "bfd4f2"
+  description: "fractal/strategies/ — BasisTrading, HyperliquidBasis, TauReset."
+
+- name: "area: loaders"
+  color: "bfd4f2"
+  description: "fractal/loaders/ — Binance, Hyperliquid, Aave, GMX, TheGraph, sims."
+
+- name: "area: core"
+  color: "bfd4f2"
+  description: "fractal/core/base/, fractal/core/pipeline.py — contracts + MLflow pipeline."
+
+- name: "area: infra"
+  color: "bfd4f2"
+  description: "setup.py, Makefile, .github/, scripts/, docs/, pre-commit, pyproject."
+
+- name: "area: tests"
+  color: "bfd4f2"
+  description: "tests/ — core, loaders, mlflow_tests."
+
+# ─── status / lifecycle ─────────────────────────────────────────
+- name: "needs-triage"
+  color: "fbca04"
+  description: "New issue — maintainer hasn't reviewed yet."
+
+- name: "blocked"
+  color: "b60205"
+  description: "Cannot progress until something external resolves."
+
+- name: "help wanted"
+  color: "008672"
+  description: "Maintainers welcome a contributor PR for this."
+
+- name: "good first issue"
+  color: "7057ff"
+  description: "Scoped narrowly; safe entry point for newcomers."
+
+- name: "wontfix"
+  color: "ffffff"
+  description: "Out of scope or by-design — closing without action."
+
+- name: "duplicate"
+  color: "cfd3d7"
+  description: "Already reported elsewhere — pointing to the canonical issue."
+
+- name: "invalid"
+  color: "e4e669"
+  description: "Not actionable as filed (insufficient repro, misuse, etc.)."
+
+# ─── meta / cross-cuts ──────────────────────────────────────────
+- name: "dependencies"
+  color: "0366d6"
+  description: "Bumps from Dependabot or manual dep changes."
+
+- name: "breaking-change"
+  color: "b60205"
+  description: "Public API change — needs a major version bump."
+
+- name: "performance"
+  color: "ff8c00"
+  description: "Throughput / memory / latency — backtest runtime."
+
+- name: "security"
+  color: "ee0701"
+  description: "Vulnerability or hardening — see SECURITY.md."
+
+- name: "release"
+  color: "5319e7"
+  description: "Release coordination — version bumps, CHANGELOG, PyPI."
+
+- name: "research"
+  color: "0e8a16"
+  description: "Notebook / study / strategy write-up under examples/ — research artifact, not framework code."

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,50 @@
+name: Sync labels
+
+# Apply ``.github/labels.yml`` to the repo's actual GitHub label set.
+#
+# Triggers on push to main when ONLY the labels file changes — the
+# main CI workflow runs PR-only (no push triggers), but labels are a
+# different beast: they should reflect the canonical state of main
+# AFTER merge, not be validated on PRs (which would attempt to apply
+# unmerged labels).
+#
+# Manual dispatch is also wired up so you can re-sync without a
+# commit (Actions → Sync labels → Run workflow).
+on:
+  push:
+    branches: [main]
+    paths: ['.github/labels.yml']
+  workflow_dispatch:
+
+# Cancel in-flight runs for the same ref so back-to-back commits to
+# labels.yml don't double-apply.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# ``EndBug/label-sync`` needs ``issues: write`` to create / update
+# / (optionally) delete labels via the REST API.
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    name: Apply labels.yml to repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync GitHub labels with .github/labels.yml
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          # ``false`` keeps any out-of-band labels that exist in the
+          # repo but aren't in our YAML (e.g. legacy ones that issues
+          # still reference). Flip to ``true`` once the repo's label
+          # set is fully migrated and you want labels.yml to be
+          # authoritative.
+          delete-other-labels: false
+          # Print the diff before applying — easy to audit in the
+          # workflow log.
+          dry-run: false

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ EXAMPLES := examples
         test test-slow test-integration test-all test-e2e smoke \
         docs docs-strict docs-serve docs-clean \
         clean clean-runs clean-all \
-        build release-test release
+        build release-test release post-release
 
 help:
 	@echo "Fractal Makefile targets"
@@ -71,6 +71,7 @@ help:
 	@echo "    build            sdist + wheel via ``python -m build``"
 	@echo "    release-test     upload dist/* to test PyPI"
 	@echo "    release          upload dist/* to PyPI"
+	@echo "    post-release     hard-reset dev to main + force-push (run AFTER squash-merging dev→main)"
 
 # ─── setup ─────────────────────────────────────────────────────────
 setup:
@@ -197,5 +198,66 @@ release: build
 	TWINE_USERNAME=__token__ \
 	TWINE_PASSWORD="$(TWINE_PASSWORD)" \
 	    $(PYTHON) -m twine upload --verbose dist/*
+
+# ─── post-release ────────────────────────────────────────────────
+# After a squash-merge ``dev → main`` PR, ``main`` carries one new
+# release commit while ``dev`` still references the original commits
+# — same content, different histories. The next PR from ``dev`` then
+# reports "N commits ahead" + "Can't automatically merge". This
+# target re-aligns ``dev`` to ``main`` by hard-reset + force-push.
+#
+# Run AFTER the release PR has been squash-merged AND no new dev
+# work has landed since. Three guards run before anything destructive:
+#   (1) must be on local ``dev``
+#   (2) working tree must be clean
+#   (3) ``origin/main`` and ``origin/dev`` must have identical content
+#       (i.e. nothing on dev that isn't already on main)
+# If you've already verified the divergence is just stale history
+# (main is canonical), bypass the third guard with ``FORCE=1``.
+# Followed by an interactive y/N prompt before the force-push.
+post-release:
+	@set -e; \
+	echo "fetching origin…"; \
+	git fetch --quiet origin; \
+	branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$branch" != "dev" ]; then \
+	    echo "ERROR: must be on dev branch (currently on '$$branch')"; \
+	    echo "  run: git checkout dev"; exit 1; \
+	fi; \
+	if ! git diff-index --quiet HEAD --; then \
+	    echo "ERROR: uncommitted changes — commit or stash first"; \
+	    git status --short; exit 1; \
+	fi; \
+	if ! git diff --quiet origin/main origin/dev; then \
+	    if [ -z "$(FORCE)" ]; then \
+	        echo "ERROR: origin/dev has content not on origin/main."; \
+	        echo "  This target syncs dev AFTER a release; if dev has"; \
+	        echo "  unreleased work, do NOT run it — open a release PR"; \
+	        echo "  first. Diff summary:"; \
+	        git diff --stat origin/main origin/dev | cat; \
+	        echo ""; \
+	        echo "  If you've verified main is the canonical state and"; \
+	        echo "  the divergence is just stale dev history, re-run:"; \
+	        echo "      make post-release FORCE=1"; \
+	        exit 1; \
+	    fi; \
+	    echo "FORCE=1 — skipping content-equality guard. Diff:"; \
+	    git diff --stat origin/main origin/dev | cat; \
+	fi; \
+	main_sha=$$(git rev-parse --short origin/main); \
+	dev_sha=$$(git rev-parse --short origin/dev); \
+	echo ""; \
+	echo "About to:"; \
+	echo "  git reset --hard origin/main      # dev $$dev_sha -> $$main_sha"; \
+	echo "  git push --force-with-lease origin dev"; \
+	echo ""; \
+	printf "Continue? [y/N] "; \
+	read ans; \
+	case "$$ans" in y|Y|yes|YES) ;; *) echo "aborted"; exit 1 ;; esac; \
+	git reset --hard origin/main; \
+	git push --force-with-lease origin dev; \
+	echo ""; \
+	echo "dev re-aligned to main ($$main_sha). Next dev -> main PR"; \
+	echo "will show only post-release commits."
 
 .DEFAULT_GOAL := help

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,34 @@
 # Release Notes
-1. Run tests
+1. Update library version in `setup.py`
+2. Last smoke local run
 ```
-make .venv
-source venv/bin/activate
-export PYTHONPATH=/path/to/Fractal
-cd tests/
-pytest -vvs
+git checkout main && git pull origin main
+make clean
+make smoke
 ```
-2. Update library version in `setup.py`
-3. Generate new docs (more info in docs/README.md)
-4. Deploy package at PyPi:
+3. Release to TestPyPi and test
+```bash
+make release-test
+python3 -m venv /tmp/ck && /tmp/ck/bin/pip install \
+    --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    fractal-defi==1.4.0 && rm -rf /tmp/ck
 ```
-pip install setuptools
-python setup.py sdist bdist_wheel
-pip install twine
-twine upload dist/*
+4. Release to PyPi
+```bash
+make release
+```
+5. Create tag and release in repo or run:
+```bash
+git tag -a v1.4.0 -m "v1.4.0"
+git push origin v1.4.0
+
+gh release create v1.4.0 --generate-notes \
+    dist/fractal_defi-1.4.0-py3-none-any.whl \
+    dist/fractal_defi-1.4.0.tar.gz
+```
+6. After squash and merge PR run:
+```bash
+git checkout dev
+make post-release
 ```


### PR DESCRIPTION
## Summary

.github: issue templates, dependabot, label sync and public docs improvement
## What changed

<!-- Bullet list, one line per item. Group by area if helpful. -->

- [ ] entities:
- [ ] strategies:
- [ ] loaders:
- [ ] pipeline / MLflow:
- [x] tests / docs:

## Test plan

<!-- Commands you ran locally + their outcome. Mark each with ✓ when green. -->

- [x] `pytest -m core`
- [x] `pytest -m slow` (if real-data / CSV-replay touched)
- [x] `pytest -m integration` (if loaders / external APIs touched)
- [x] `flake8 fractal/ tests/` and `pylint fractal/`
- [x] `cd docs && make html` (if docstrings / Sphinx config touched)
- [x] `bash tests/mlflow_tests/scripts/e2e.sh` (if pipeline / examples touched)

## Checklist

- [ ] PR targets `dev`
- [x] Appropriate label applied
- [ ] CHANGELOG.md updated (under the relevant `Unreleased` heading)
- [ ] Lock-in test added for any closed bug
- [ ] Reviewer requested
