### PR TITLE
v1.3.2 - Release Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to **fractal-defi** are documented here. The format
 is loosely based on [Keep a Changelog](https://keepachangelog.com/),
 with one-line bullets per change.
 
+## [v1.3.2] — 2026-05-06
+
+Citation infrastructure for academic use. No functional code changes;
+existing strategies, entities, loaders and pipeline behaviour are
+identical to v1.3.1.
+
+### Added
+
+- **`CITATION.cff`** — Citation File Format metadata in the repo
+  root. GitHub renders a "Cite this repository" button on the project
+  page that exports BibTeX and APA forms automatically.
+- **`README.md` Citation section** — pre-formatted BibTeX block and
+  pointer to `CITATION.cff` for users who want to cite Fractal in
+  publications.
+- **Zenodo archival enabled** — releases from this version onward
+  are automatically archived on Zenodo with a permanent DOI, so
+  Fractal can be cited as a first-class scholarly artifact in
+  CrossRef / Google Scholar.
+
 ## [v1.3.1] — 2026-05-01
 
 Dependency floors aligned with the actually-tested matrix, Uniswap V2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.2.0
+message: "If you use Fractal in academic work, please cite it as below."
+title: "Fractal: A Python Research Library for DeFi Strategies"
+abstract: >-
+  Open-source Python research library for DeFi strategies.
+  Compose protocol-agnostic entities (lending, perps, DEX and LP)
+  into typed strategies; backtest, simulate, and track experiments
+  with MLflow.
+type: software
+authors:
+  - given-names: "Anatoly"
+    family-names: "Krestenko"
+    affiliation: "Independent Researcher"
+    email: "xboringwozniak@gmail.com"
+  - name: "the Fractal contributors"
+version: 1.3.2
+date-released: 2026-05-06
+license: BSD-3-Clause
+repository-code: "https://github.com/Logarithm-Labs/fractal-defi"
+url: "https://github.com/Logarithm-Labs/fractal-defi"
+keywords:
+  - defi
+  - backtesting
+  - quantitative-finance
+  - algorithmic-trading
+  - uniswap-v3
+  - aave
+  - delta-neutral
+  - liquidity-provision
+  - monte-carlo
+  - mlflow

--- a/README.md
+++ b/README.md
@@ -195,6 +195,26 @@ python examples/basis/grid.py
 - Sphinx API reference can be built locally from the repo
   (`make docs`); a hosted version is on the project's docs site.
 
+## Citation
+
+If you use Fractal in academic work, please cite it. Citation
+metadata lives in [`CITATION.cff`](CITATION.cff) — GitHub renders a
+"Cite this repository" button on the repo page that exports BibTeX
+and APA forms automatically.
+
+BibTeX:
+
+```bibtex
+@software{fractal_defi,
+  author    = {Krestenko, Anatoly and {the Fractal contributors}},
+  title     = {Fractal: A Python Research Library for {DeFi} Strategies},
+  version   = {1.3.2},
+  year      = {2026},
+  url       = {https://github.com/Logarithm-Labs/fractal-defi},
+  license   = {BSD-3-Clause}
+}
+```
+
 ## License
 
 BSD 3-Clause. See [`LICENSE`](LICENSE).

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ DEV_REQUIRES = [
 
 setup(
     name='fractal-defi',
-    version='1.3.1',
+    version='1.3.2',
     packages=find_packages(),
     author='Logarithm Labs',
     author_email='xboringwozniak@gmail.com',


### PR DESCRIPTION
## Release v1.3.1                                                                     
                                                                                      
Citation infrastructure for academic use. No functional code changes.
                                                        
### Full changelog                                                                    
                                                                                      
See [`CHANGELOG.md`](CHANGELOG.md) `[v1.3.2]` section for the complete list.
                                                                                      
### Pre-merge checklist                                            

- [x] `make smoke` green locally                                                      
- [x] `make pre-commit` green (lint at 10/10, isort clean)
- [x] `make docs-strict` builds with 0 warnings                                       
- [x] `pytest -m core` 1116/1116 ✓                                                    
- [x] `pytest -m slow` 44/44 ✓                                                        
- [x] `pytest -m integration` 64/64 ✓ (with `THE_GRAPH_API_KEY`)                      
- [x] CHANGELOG.md updated, `version='1.3.1'` in setup.py                             
- [x] `fractal.__version__` matches `setup.py::version`                               
- [x] Review CI status (lint, core-tests matrix, docs, smoke, e2e) 