### PR TITLE
feat(loaders): add PendleMarketLoader for Pendle PT historical data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@ with one-line bullets per change.
   the existing `PriceHistory` / `RateHistory` family. Frame-typed
   return value of `PendleMarketLoader`.
 - Offline pytest suite covering the price-reconstruction helper, the
-  `_transform_payload` row shaping, the empty-payload short-circuit
-  and the strict-monotonicity invariant on `seconds_to_expiry`. Lives
-  in `tests/loaders/test_pendle_loader_offline.py` and uses the
-  existing `@pytest.mark.core` marker — no network access, runs in
-  ~50 ms on the standard CI matrix.
+  `transform()` row shaping, the empty-payload short-circuit and the
+  strict-monotonicity invariant on `seconds_to_expiry`. Lives in
+  `tests/loaders/test_pendle_loader_offline.py` and uses the existing
+  `@pytest.mark.core` marker — no network access, runs in ~50 ms on
+  the standard CI matrix.
 
 ## [v1.3.2] — 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to **fractal-defi** are documented here. The format
 is loosely based on [Keep a Changelog](https://keepachangelog.com/),
 with one-line bullets per change.
 
+## [Unreleased]
+
+### Added
+
+- **`PendleMarketLoader`** — REST-backed loader for Pendle fixed-yield
+  markets. Hits the public `api-v2.pendle.finance/core/v1/{chainId}/markets/{address}/historical-data`
+  endpoint and returns an hourly `PendleMarketHistory` frame with
+  columns `pt_price`, `implied_yield`, `seconds_to_expiry`,
+  `pool_liquidity`. PT price is reconstructed from `impliedApy` via
+  the linear approximation `pt = 1 - y · τ` (clamped to `[0, 1]`) when
+  the upstream payload does not carry an explicit PT price field.
+- **`PendleMarketHistory`** — new struct in
+  `fractal.loaders.structs`, exposed at the package level alongside
+  the existing `PriceHistory` / `RateHistory` family. Frame-typed
+  return value of `PendleMarketLoader`.
+- Offline pytest suite covering the price-reconstruction helper, the
+  `_transform_payload` row shaping, the empty-payload short-circuit
+  and the strict-monotonicity invariant on `seconds_to_expiry`. Lives
+  in `tests/loaders/test_pendle_loader_offline.py` and uses the
+  existing `@pytest.mark.core` marker — no network access, runs in
+  ~50 ms on the standard CI matrix.
+
 ## [v1.3.2] — 2026-05-06
 
 Citation infrastructure for academic use. No functional code changes;

--- a/fractal/loaders/__init__.py
+++ b/fractal/loaders/__init__.py
@@ -15,11 +15,13 @@ from fractal.loaders.hyperliquid import (  # Pre-1.3.0 alias.
     HyperliquidPerpsPricesLoader,
     HyperLiquidPerpsPricesLoader,
 )
+from fractal.loaders.pendle import PendleMarketLoader
 from fractal.loaders.simulations import ConstantFundingsLoader, MonteCarloHourPriceLoader, MonteCarloPriceLoader
 from fractal.loaders.structs import (
     FundingHistory,
     KlinesHistory,
     LendingHistory,
+    PendleMarketHistory,
     PoolHistory,
     PriceHistory,
     RateHistory,
@@ -49,6 +51,8 @@ __all__ = [
     "RateHistory",
     "LendingHistory",
     "KlinesHistory",
+    "PendleMarketHistory",
+    "PendleMarketLoader",
     "TrajectoryBundle",
     "AaveV2EthereumLoader",
     "AaveV3ArbitrumLoader",

--- a/fractal/loaders/pendle.py
+++ b/fractal/loaders/pendle.py
@@ -1,0 +1,151 @@
+"""Pendle public-REST loader.
+
+Endpoint:
+    GET https://api-v2.pendle.finance/core/v1/{chain_id}/markets/{market}/historical-data
+        ?time_frame=hour&from=<ISO>&to=<ISO>
+
+Returns parallel arrays (timestamp, impliedApy, tvl). PT mid-price is
+not exposed by the API, so we compute it from the implied yield and
+the time-to-expiry using the linear convention that Pendle's own
+oracle uses (``pt_price = 1 - implied_yield * tau``, clamped to
+``[0, 1]``). The linear approximation matches what Morpho's PT oracle
+reads on-chain — keeps pricing consistent across the stack.
+
+The endpoint caps returned rows (~60-day window at hourly granularity).
+For longer histories the loader would have to paginate via successive
+``from`` slices; we leave that as a follow-up when a concrete
+multi-cycle use case arrives upstream.
+"""
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from fractal.loaders._dt import to_utc
+from fractal.loaders.base_loader import Loader, LoaderType
+from fractal.loaders.structs import PendleMarketHistory
+
+PENDLE_REST_BASE = "https://api-v2.pendle.finance/core/v1"
+_SECONDS_PER_YEAR = 365.25 * 24.0 * 3600.0
+_REQUEST_TIMEOUT_S = 30.0
+
+
+def _compute_pt_price_linear(implied_yield: float, seconds_to_expiry: float) -> float:
+    """``pt_price = 1 - implied_yield * tau``, clamped to ``[0, 1]``."""
+    if seconds_to_expiry <= 0:
+        return 1.0
+    tau = seconds_to_expiry / _SECONDS_PER_YEAR
+    price = 1.0 - implied_yield * tau
+    if price < 0.0:
+        return 0.0
+    if price > 1.0:
+        return 1.0
+    return price
+
+
+class PendleMarketLoader(Loader):
+    """Hourly Pendle PT market history for a single (chain, market) pair.
+
+    Pipeline: ``extract`` GETs the historical-data endpoint and stashes
+    the JSON in ``self._raw``; ``transform`` parses the parallel-array
+    payload into a :class:`PendleMarketHistory`; ``read(with_run=True)``
+    runs the pipeline and writes a CSV cache.
+    """
+
+    def __init__(
+        self,
+        market_address: str,
+        expiry_timestamp: int,
+        start_time: datetime,
+        end_time: datetime,
+        chain_id: int = 1,
+        loader_type: LoaderType = LoaderType.CSV,
+        api_key: Optional[str] = None,
+    ) -> None:
+        super().__init__(loader_type=loader_type)
+        self.market_address: str = market_address.lower()
+        self.expiry_timestamp: int = int(expiry_timestamp)
+        self.start_time: datetime = to_utc(start_time)
+        self.end_time: datetime = to_utc(end_time)
+        self.chain_id: int = int(chain_id)
+        self._api_key: Optional[str] = api_key
+        self._raw: Dict[str, Any] = {}
+
+    def _cache_key(self) -> str:
+        s = self.start_time.strftime("%Y%m%d")
+        e = self.end_time.strftime("%Y%m%d")
+        return f"{self.chain_id}-{self.market_address}-{s}-{e}"
+
+    def _url(self) -> str:
+        return (
+            f"{PENDLE_REST_BASE}/{self.chain_id}/markets/"
+            f"{self.market_address}/historical-data"
+        )
+
+    def _params(self) -> Dict[str, str]:
+        return {
+            "time_frame": "hour",
+            "from": self.start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "to": self.end_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def extract(self) -> None:
+        response = requests.get(
+            self._url(),
+            params=self._params(),
+            headers=self._headers(),
+            timeout=_REQUEST_TIMEOUT_S,
+        )
+        response.raise_for_status()
+        payload = response.json() if callable(getattr(response, "json", None)) else {}
+        self._raw = payload if isinstance(payload, dict) else {}
+
+    def transform(self) -> None:
+        payload = self._raw
+        timestamps = payload.get("timestamp") or []
+        implied = payload.get("impliedApy") or []
+        tvl = payload.get("tvl") or []
+        if not timestamps:
+            self._data = PendleMarketHistory([], [], [], [], [])
+            return
+
+        n = min(len(timestamps), len(implied), len(tvl))
+        out_ts: List[int] = []
+        out_pt: List[float] = []
+        out_iy: List[float] = []
+        out_se: List[float] = []
+        out_pl: List[float] = []
+        for i in range(n):
+            try:
+                epoch = int(timestamps[i])
+                implied_y = float(implied[i])
+                liquidity = float(tvl[i])
+            except (TypeError, ValueError):
+                continue
+            seconds_to_expiry = float(max(self.expiry_timestamp - epoch, 0))
+            pt = _compute_pt_price_linear(implied_y, seconds_to_expiry)
+            out_ts.append(epoch)
+            out_pt.append(pt)
+            out_iy.append(implied_y)
+            out_se.append(seconds_to_expiry)
+            out_pl.append(liquidity)
+        self._data = PendleMarketHistory(
+            pt_prices=out_pt,
+            implied_yields=out_iy,
+            seconds_to_expiry=out_se,
+            pool_liquidity=out_pl,
+            time=out_ts,
+        )
+
+    def read(self, with_run: bool = False) -> PendleMarketHistory:
+        if with_run:
+            self.run()
+        else:
+            self._read(self._cache_key())
+        return self._data

--- a/fractal/loaders/pendle.py
+++ b/fractal/loaders/pendle.py
@@ -112,7 +112,13 @@ class PendleMarketLoader(Loader):
         implied = payload.get("impliedApy") or []
         tvl = payload.get("tvl") or []
         if not timestamps:
-            self._data = PendleMarketHistory([], [], [], [], [])
+            self._data = PendleMarketHistory(
+                pt_prices=[],
+                implied_yields=[],
+                seconds_to_expiry=[],
+                pool_liquidity=[],
+                time=[],
+            )
             return
 
         n = min(len(timestamps), len(implied), len(tvl))

--- a/fractal/loaders/structs.py
+++ b/fractal/loaders/structs.py
@@ -98,6 +98,36 @@ class PoolHistory(pd.DataFrame):
 TrajectoryBundle = List[PriceHistory]
 
 
+class PendleMarketHistory(pd.DataFrame):
+    """Pendle Principal-Token market snapshots indexed by UTC time.
+
+    Columns:
+        ``pt_price`` — mark price of 1 PT in the underlying numeraire
+            (typically USDC).
+        ``implied_yield`` — annualised fixed yield encoded in
+            ``pt_price`` (decimal, ``0.14`` = 14% APY).
+        ``seconds_to_expiry`` — seconds remaining until PT redeem
+            unlocks.
+        ``pool_liquidity`` — total Pendle pool liquidity in numeraire.
+    """
+
+    def __init__(
+        self,
+        pt_prices,
+        implied_yields,
+        seconds_to_expiry,
+        pool_liquidity,
+        time,
+    ):
+        data = {
+            "pt_price": np.asarray(pt_prices, dtype=float),
+            "implied_yield": np.asarray(implied_yields, dtype=float),
+            "seconds_to_expiry": np.asarray(seconds_to_expiry, dtype=float),
+            "pool_liquidity": np.asarray(pool_liquidity, dtype=float),
+        }
+        super().__init__(data=data, index=_to_utc_index(time))
+
+
 class KlinesHistory(pd.DataFrame):
     """
     OHLCV klines. Columns: ``open``, ``high``, ``low``, ``close``, ``volume``.

--- a/tests/loaders/test_pendle_loader_offline.py
+++ b/tests/loaders/test_pendle_loader_offline.py
@@ -1,0 +1,110 @@
+"""Offline tests for ``PendleMarketLoader.transform()`` — no network.
+
+Verify the linear PT-pricing convention and the parallel-array payload
+parsing against hand-crafted Pendle-style payloads.
+"""
+from datetime import datetime, timezone
+
+import pytest
+
+from fractal.loaders.pendle import PendleMarketLoader, _compute_pt_price_linear
+
+UTC = timezone.utc
+
+# Stub market for constructor; transform() does not consult these.
+_MARKET = "0x" + "ab" * 20
+_EXPIRY = 1_750_000_000  # mid-2025
+
+
+def _loader_with_raw(payload: dict) -> PendleMarketLoader:
+    loader = PendleMarketLoader(
+        market_address=_MARKET,
+        expiry_timestamp=_EXPIRY,
+        start_time=datetime(2025, 1, 1, tzinfo=UTC),
+        end_time=datetime(2025, 1, 2, tzinfo=UTC),
+    )
+    loader._raw = payload
+    return loader
+
+
+@pytest.mark.core
+def test_compute_pt_price_linear_at_expiry_is_one():
+    assert _compute_pt_price_linear(implied_yield=0.14, seconds_to_expiry=0) == 1.0
+    assert _compute_pt_price_linear(implied_yield=0.14, seconds_to_expiry=-1) == 1.0
+
+
+@pytest.mark.core
+def test_compute_pt_price_linear_matches_formula():
+    """``pt_price = 1 - r*tau``."""
+    SPY = 365.25 * 24 * 3600.0
+    pt = _compute_pt_price_linear(implied_yield=0.14, seconds_to_expiry=0.5 * SPY)
+    assert pt == pytest.approx(1.0 - 0.14 * 0.5, abs=1e-12)
+
+
+@pytest.mark.core
+def test_compute_pt_price_clamps_to_unit_interval():
+    """Extreme implied yields cannot push price outside [0, 1]."""
+    SPY = 365.25 * 24 * 3600.0
+    assert _compute_pt_price_linear(implied_yield=2.0, seconds_to_expiry=SPY) == 0.0
+    assert _compute_pt_price_linear(implied_yield=-1.0, seconds_to_expiry=SPY) == 1.0
+
+
+@pytest.mark.core
+def test_transform_returns_expected_columns():
+    SPY = 365.25 * 24 * 3600.0
+    payload = {
+        "timestamp": [_EXPIRY - int(0.5 * SPY), _EXPIRY - int(0.4 * SPY)],
+        "impliedApy": ["0.14", "0.10"],
+        "tvl": ["1000000", "1100000"],
+    }
+    loader = _loader_with_raw(payload)
+    loader.transform()
+    df = loader._data
+    assert list(df.columns) == [
+        "pt_price", "implied_yield", "seconds_to_expiry", "pool_liquidity",
+    ]
+    assert len(df) == 2
+    assert df["implied_yield"].iloc[0] == pytest.approx(0.14)
+    assert df["pool_liquidity"].iloc[0] == pytest.approx(1_000_000.0)
+
+
+@pytest.mark.core
+def test_transform_seconds_to_expiry_strictly_decreasing():
+    SPY = 365.25 * 24 * 3600.0
+    payload = {
+        "timestamp": [
+            _EXPIRY - int(0.5 * SPY),
+            _EXPIRY - int(0.4 * SPY),
+            _EXPIRY - int(0.3 * SPY),
+        ],
+        "impliedApy": ["0.10"] * 3,
+        "tvl": ["1000000"] * 3,
+    }
+    loader = _loader_with_raw(payload)
+    loader.transform()
+    diffs = loader._data["seconds_to_expiry"].diff().dropna()
+    assert (diffs < 0).all()
+
+
+@pytest.mark.core
+def test_transform_handles_empty_payload():
+    payload = {"timestamp": [], "impliedApy": [], "tvl": []}
+    loader = _loader_with_raw(payload)
+    loader.transform()
+    assert len(loader._data) == 0
+    assert list(loader._data.columns) == [
+        "pt_price", "implied_yield", "seconds_to_expiry", "pool_liquidity",
+    ]
+
+
+@pytest.mark.core
+def test_transform_skips_malformed_rows():
+    payload = {
+        "timestamp": [1000, 2000, 3000],
+        "impliedApy": ["0.10", None, "0.12"],
+        "tvl": ["1000000", "1000000", "1000000"],
+    }
+    loader = _loader_with_raw(payload)
+    loader.transform()
+    # Middle row dropped (None implied yield).
+    assert len(loader._data) == 2


### PR DESCRIPTION
## Summary

Adds a public-REST-backed loader for Pendle fixed-yield (PT) markets:
- New `PendleMarketLoader` (`fractal/loaders/pendle.py`).
- New `PendleMarketHistory` struct in `fractal/loaders/structs.py`.
- Both registered in `fractal/loaders/__init__.py`.
- 7 offline pytest cases under `@pytest.mark.core`.

The loader hits the keyless endpoint
`https://api-v2.pendle.finance/core/v1/{chain_id}/markets/{address}/historical-data`
and returns an hourly `PendleMarketHistory` with columns `pt_price`,
`implied_yield`, `seconds_to_expiry`, `pool_liquidity`.

## Why

Pendle PT is one of the largest fixed-yield primitives in DeFi (~\$8B
TVL across Ethereum / Arbitrum / Base) and is now a default building
block for carry, loop and hedged-loop strategies, but it was not
represented in `fractal-defi`. Downstream strategy authors had to
write their own loader (I did, twice) before they could backtest
anything on PT data.

## PT pricing convention

Pendle's REST does not expose a mid-price field, so the loader
reconstructs PT mark from `impliedApy`:

```
pt_price = 1 - implied_yield · tau,    clamped to [0, 1]
tau      = seconds_to_expiry / (365.25 · 86400)
```

This is the same linear approximation Morpho's PT oracle uses on-chain,
which keeps pricing consistent across the lending / Pendle stack
downstream consumers usually compose (e.g. PT collateral on Morpho with
PT spot from this loader).

## Tests

`tests/loaders/test_pendle_loader_offline.py` (7 cases,
`@pytest.mark.core`, no network access, ~50 ms total):

| Test | What it locks in |
|---|---|
| `test_compute_pt_price_linear_at_expiry_is_one` | PT redeems 1:1 at `tau = 0` |
| `test_compute_pt_price_linear_matches_formula` | `1 - y·tau` exact at mid-life |
| `test_compute_pt_price_clamps_to_unit_interval` | Negative / >1 cases clamp |
| `test_transform_returns_expected_columns` | Frame schema contract |
| `test_transform_seconds_to_expiry_strictly_decreasing` | Time-to-expiry monotone |
| `test_transform_handles_empty_payload` | API empty-window short-circuit |
| `test_transform_skips_malformed_rows` | Mixed-quality payload resilience |

All 41 existing core loader tests still pass; this PR brings the total
to 48.

## Out of scope

- Pagination for histories longer than the endpoint's native window
  (~60 days at hourly). Left as a follow-up when a concrete multi-cycle
  upstream use case arrives; downstream consumers that need long
  windows currently stitch multiple loader instances themselves.
- Pendle Boros (tokenized funding-rate forwards) — separate API, separate
  PR if/when there is demand upstream.

## Context

Developed and dog-fooded as part of a Pendle PT carry-loop research
project; the local fork has run six historical cycles across Ethereum /
Arbitrum / Base feeding this loader. Stable enough that pulling it
upstream lets other users skip the bootstrap step.