### PR TITLE
feat: Pendle PT carry-loop stack — 3 entities + 3 loaders + typed structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to **fractal-defi** are documented here. The format
 is loosely based on [Keep a Changelog](https://keepachangelog.com/),
 with one-line bullets per change.
 
+## [Unreleased]
+
+Pendle PT carry-loop stack: three new protocol entities (Pendle PT,
+Morpho Blue, perpetual-funding hedge) and three new historical-data
+loaders (Pendle, Morpho, Boros), all with typed `*History` structs and
+offline test coverage. Adds first-class primitives for fixed-yield
+leveraged carry strategies on Pendle / Morpho / Boros stacks.
+
+### Added — Entities (`fractal.core.entities.protocols`)
+
+- **`PendlePTEntity`** — Pendle Principal Token position. Tracks a PT
+  face amount, an AMM cash leg, and exposes `action_buy_pt` /
+  `action_sell_pt` (with `amm_fee_rate` + linear `slippage_factor`
+  scaled by trade-to-pool ratio) and `action_redeem` (1:1 at expiry,
+  optionally `sy_price_in_usdc < 1` to model underlying depeg at
+  redeem). Linear `pt = 1 - implied_yield · tau` pricing matches
+  Morpho's PT oracle convention for cross-stack consistency.
+  Closed-form helper `compute_pt_price` for scenario projection.
+- **`MorphoEntity`** — Morpho Blue isolated lending market. Extends
+  `BaseLendingEntity`. Single `lltv` parameter per instance, debt
+  accrues at `borrowing_rate * dt`, post-mutation LLTV guard on
+  `action_borrow` / `action_withdraw` (atomic rollback on violation),
+  latching `is_liquidated` flag when an observation pushes
+  `ltv > lltv`.
+- **`FundingHedgeEntity`** — abstract perpetual-funding carry leg.
+  Linear PnL accrual `s · notional · funding_rate · dt`, `s ∈ {±1}`
+  via `FundingHedgeConfig.direction`. Models Pendle Boros tokens or a
+  delta-neutral Hyperliquid funding hedge without booking the
+  spot/futures offset leg (assumed perfect and free).
+
+### Added — Loaders (`fractal.loaders`)
+
+- **`PendleMarketLoader`** — REST-backed loader for Pendle fixed-yield
+  markets. Hits the keyless
+  `api-v2.pendle.finance/core/v1/{chain_id}/markets/{address}/historical-data`
+  endpoint and returns hourly `PendleMarketHistory` (columns:
+  `pt_price`, `implied_yield`, `seconds_to_expiry`, `pool_liquidity`).
+- **`MorphoMarketLoader`** — GraphQL-backed loader for Morpho Blue
+  isolated markets. Hits the keyless `blue-api.morpho.org/graphql`
+  endpoint and returns hourly `MorphoMarketHistory` (columns:
+  `borrowing_rate`, `utilization`, `supply_apy`). Chain routing:
+  `ethereum` / `arbitrum` / `base`.
+- **`BorosMarketLoader`** — REST-backed loader for Pendle Boros
+  funding-rate-forward markets. Returns recent `BorosMarketHistory`
+  (columns: `mark_apr`, `observed_funding`, `mark_apr_7d_ma`,
+  `mark_apr_30d_ma`). Endpoint returns ~500 most recent bars
+  irrespective of `from` / `to` — recent-only coverage documented in
+  the module docstring.
+
+### Added — Typed structs (`fractal.loaders.structs`)
+
+- `PendleMarketHistory`, `MorphoMarketHistory`, `BorosMarketHistory`
+  alongside the existing `PriceHistory` / `RateHistory` family.
+
+### Added — Tests
+
+- 6 new offline pytest modules under `@pytest.mark.core`, 47 new test
+  cases in total (no network access). Coverage spans
+  fee/slippage round-trips, LLTV guards and rollback atomicity,
+  PnL accrual closed-forms, payload-parsing edge cases, struct
+  contracts and chain routing. Total runtime ~0.4 s.
+
 ## [v1.3.2] — 2026-05-06
 
 Citation infrastructure for academic use. No functional code changes;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,17 +21,23 @@ leveraged carry strategies on Pendle / Morpho / Boros stacks.
   optionally `sy_price_in_usdc < 1` to model underlying depeg at
   redeem). Linear `pt = 1 - implied_yield · tau` pricing matches
   Morpho's PT oracle convention for cross-stack consistency.
+  Post-expiry `balance` marks PT face at `sy_price_in_usdc`, so
+  underlying depeg reaches NAV before `action_redeem` is called.
   Closed-form helper `compute_pt_price` for scenario projection.
 - **`MorphoEntity`** — Morpho Blue isolated lending market. Extends
-  `BaseLendingEntity`. Single `lltv` parameter per instance, debt
-  accrues at `borrowing_rate * dt`, post-mutation LLTV guard on
-  `action_borrow` / `action_withdraw` (atomic rollback on violation),
-  latching `is_liquidated` flag when an observation pushes
-  `ltv > lltv`.
+  `BaseLendingEntity`. Single `lltv` parameter per instance (validated
+  to ``(0, 1]`` at construction), debt accrues at `borrowing_rate * dt`,
+  post-mutation LLTV guard on `action_borrow` / `action_withdraw`
+  (atomic rollback on violation), latching `is_liquidated` flag when
+  an observation pushes `ltv > lltv`. The derived `ltv` returns
+  `+inf` for insolvent states (positive debt, non-positive
+  collateral), so the latch fires deterministically on collateral
+  wipes.
 - **`FundingHedgeEntity`** — abstract perpetual-funding carry leg.
   Linear PnL accrual `s · notional · funding_rate · dt`, `s ∈ {±1}`
-  via `FundingHedgeConfig.direction`. Models Pendle Boros tokens or a
-  delta-neutral Hyperliquid funding hedge without booking the
+  via `FundingHedgeConfig.direction` (rejected at construction if
+  not exactly `"long"` or `"short"`). Models Pendle Boros tokens or
+  a delta-neutral Hyperliquid funding hedge without booking the
   spot/futures offset leg (assumed perfect and free).
 
 ### Added — Loaders (`fractal.loaders`)
@@ -39,32 +45,64 @@ leveraged carry strategies on Pendle / Morpho / Boros stacks.
 - **`PendleMarketLoader`** — REST-backed loader for Pendle fixed-yield
   markets. Hits the keyless
   `api-v2.pendle.finance/core/v1/{chain_id}/markets/{address}/historical-data`
-  endpoint and returns hourly `PendleMarketHistory` (columns:
-  `pt_price`, `implied_yield`, `seconds_to_expiry`, `pool_liquidity`).
+  endpoint via the shared `HttpClient` (retry + backoff) and returns
+  hourly `PendleMarketHistory` (columns: `pt_price`, `implied_yield`,
+  `seconds_to_expiry`, `pool_liquidity`, plus optional `base_apy`,
+  `underlying_apy`, `max_apy` from the same payload). Validates the
+  market address against the standard EVM-address regex; rejects
+  unsupported `chain_id` values and reversed `start/end` windows.
 - **`MorphoMarketLoader`** — GraphQL-backed loader for Morpho Blue
   isolated markets. Hits the keyless `blue-api.morpho.org/graphql`
-  endpoint and returns hourly `MorphoMarketHistory` (columns:
-  `borrowing_rate`, `utilization`, `supply_apy`). Chain routing:
-  `ethereum` / `arbitrum` / `base`.
+  endpoint via the shared `HttpClient` and returns hourly
+  `LendingHistory` with the now-optional `utilization` column
+  populated. Chain routing: `ethereum` / `arbitrum` / `base`.
+  Validates the 32-byte hex market id at construction (not only the
+  `0x` prefix).
 - **`BorosMarketLoader`** — REST-backed loader for Pendle Boros
   funding-rate-forward markets. Returns recent `BorosMarketHistory`
   (columns: `mark_apr`, `observed_funding`, `mark_apr_7d_ma`,
   `mark_apr_30d_ma`). Endpoint returns ~500 most recent bars
   irrespective of `from` / `to` — recent-only coverage documented in
-  the module docstring.
+  the module docstring. Validates `time_frame` against the documented
+  `{5m, 1h, 1d, 1w}` set.
+- **`PendleOHLCVLoader`** — REST-backed loader for the Pendle
+  OHLCV-price endpoint (`/v4/{chain_id}/prices/{token}/ohlcv`). Returns
+  hourly (or other-granularity) `KlinesHistory` for any PT / YT / SY /
+  underlying token tracked by Pendle's oracle. Use when a candlestick
+  view of the PT mark is wanted (drawdown plots, vol estimation);
+  use `PendleMarketLoader` for the implied-yield / liquidity series
+  keyed off the *market* contract. Time-frame validated against
+  `{1m, 5m, 15m, 1h, 4h, 1d, 1w}`.
+
+All four loaders route HTTP traffic through `fractal.loaders._http.HttpClient`
+for consistent retry / backoff / `LoaderHttpError` semantics, key
+caches by full epoch-seconds (so hour-different windows on the same
+day do not collide) and rehydrate the typed `*History` struct on
+cache hits so `read(with_run=True)` and `read(with_run=False)` return
+the same type and the same UTC `DatetimeIndex`.
 
 ### Added — Typed structs (`fractal.loaders.structs`)
 
-- `PendleMarketHistory`, `MorphoMarketHistory`, `BorosMarketHistory`
-  alongside the existing `PriceHistory` / `RateHistory` family.
+- `PendleMarketHistory` and `BorosMarketHistory` typed DataFrames, both
+  with full `__init__` type annotations.
+- `LendingHistory` extended with an optional `utilization` column
+  (defaults to `NaN` so existing callers stay source-compatible).
+  `MorphoMarketLoader` populates it from the Morpho GraphQL feed.
+- `_to_utc_index` now interprets integer arrays as **Unix epoch
+  seconds** (the natural REST-API convention) rather than nanoseconds
+  — a 2025 epoch no longer lands near 1970.
 
 ### Added — Tests
 
-- 6 new offline pytest modules under `@pytest.mark.core`, 47 new test
+- 7 new offline pytest modules under `@pytest.mark.core`, 93 new test
   cases in total (no network access). Coverage spans
   fee/slippage round-trips, LLTV guards and rollback atomicity,
-  PnL accrual closed-forms, payload-parsing edge cases, struct
-  contracts and chain routing. Total runtime ~0.4 s.
+  PnL accrual closed-forms, payload-parsing edge cases, config
+  validation (config-level `lltv` band, `direction` enum,
+  `time_frame` enum), struct contracts, chain routing,
+  EVM-address regex validation, full epoch-seconds cache keys,
+  typed-struct cache rehydration and UTC-seconds index conversion.
+  Total runtime ~0.5 s.
 
 ## [v1.3.2] — 2026-05-06
 

--- a/fractal/core/entities/protocols/__init__.py
+++ b/fractal/core/entities/protocols/__init__.py
@@ -6,6 +6,12 @@ math, Lido staking rewards). Use them to backtest strategies against
 actual protocol behaviour.
 """
 from fractal.core.entities.protocols.aave import AaveEntity, AaveGlobalState
+from fractal.core.entities.protocols.funding_hedge import (
+    FundingHedgeConfig,
+    FundingHedgeEntity,
+    FundingHedgeGlobalState,
+    FundingHedgeInternalState,
+)
 from fractal.core.entities.protocols.hyperliquid import (  # Pre-1.3.0 aliases â€” re-exported for back-compat.
     HyperliquidEntity,
     HyperliquidGlobalState,
@@ -15,6 +21,19 @@ from fractal.core.entities.protocols.hyperliquid import (  # Pre-1.3.0 aliases â
     HyperliquidPosition,
     HyperLiquidPosition,
 )
+from fractal.core.entities.protocols.morpho import (
+    MorphoConfig,
+    MorphoEntity,
+    MorphoGlobalState,
+    MorphoInternalState,
+)
+from fractal.core.entities.protocols.pendle_pt import (
+    PendlePTConfig,
+    PendlePTEntity,
+    PendlePTGlobalState,
+    PendlePTInternalState,
+    compute_pt_price,
+)
 from fractal.core.entities.protocols.steth import StakedETHEntity, StakedETHGlobalState
 from fractal.core.entities.protocols.uniswap_v2_lp import UniswapV2LPConfig, UniswapV2LPEntity, UniswapV2LPGlobalState
 from fractal.core.entities.protocols.uniswap_v3_lp import UniswapV3LPConfig, UniswapV3LPEntity, UniswapV3LPGlobalState
@@ -22,10 +41,16 @@ from fractal.core.entities.protocols.uniswap_v3_spot import UniswapV3SpotEntity,
 
 __all__ = [
     "AaveEntity", "AaveGlobalState",
+    "FundingHedgeConfig", "FundingHedgeEntity",
+    "FundingHedgeGlobalState", "FundingHedgeInternalState",
     "HyperliquidEntity",
     "HyperliquidGlobalState", "HyperliquidInternalState", "HyperliquidPosition",
     # Pre-1.3.0 aliases (deprecated; will be removed in a future major release).
     "HyperLiquidGlobalState", "HyperLiquidInternalState", "HyperLiquidPosition",
+    "MorphoConfig", "MorphoEntity",
+    "MorphoGlobalState", "MorphoInternalState",
+    "PendlePTConfig", "PendlePTEntity",
+    "PendlePTGlobalState", "PendlePTInternalState", "compute_pt_price",
     "StakedETHEntity", "StakedETHGlobalState",
     "UniswapV2LPConfig", "UniswapV2LPEntity", "UniswapV2LPGlobalState",
     "UniswapV3LPConfig", "UniswapV3LPEntity", "UniswapV3LPGlobalState",

--- a/fractal/core/entities/protocols/funding_hedge.py
+++ b/fractal/core/entities/protocols/funding_hedge.py
@@ -1,0 +1,239 @@
+"""Funding-rate hedge entity — Session 6.
+
+A *funding-rate carry* leg: a notional long (or short) position whose
+PnL stream is the cumulative perpetual-funding cashflow,
+
+.. math::
+
+    \\Delta\\text{PnL} = s \\cdot N \\cdot r_f \\cdot \\Delta t,
+
+where :math:`N` is the notional, :math:`r_f` is the annualised funding
+rate, :math:`\\Delta t` is in years, and :math:`s \\in \\{+1, -1\\}` is
+the side sign (``+1`` for the long-funding side that *receives* funding
+when the rate is positive).
+
+Why this matters for the PT-sUSDe loop
+--------------------------------------
+The PT-sUSDe collateral pays a fixed yield (the PT discount unwinding
+to par at expiry), but the *implied yield* market — the price at which
+new PT trades — can drift between deposit and exit. That drift mirrors
+the perpetual-funding regime for sUSDe-style assets: the same demand
+for delta-neutral USD carry that drives Pendle's implied yield is what
+drives perp funding on hyperliquid USDe / sUSDe pairs. A long-funding
+position therefore acts as a partial hedge on implied-yield risk.
+
+Pendle's *Boros* product tokenises exactly this leg (a tradable claim
+on a funding-rate stream); for our backtest we model the stream
+directly rather than wrapping it in a token, since the position is
+held passively and never traded out into a token-market secondary.
+
+Scope / non-goals
+-----------------
+* No price exposure is modelled. This is purely the carry abstraction
+  — the funding-leg PnL stream, decoupled from the underlying mark.
+  In production we'd close the delta with a spot or futures offset; in
+  the backtest we assume that hedge is perfect and free, which is the
+  standard idealisation for funding-rate carry research.
+* No funding-payment cadence is enforced. Hyperliquid funds hourly,
+  but the loader is responsible for *annualising* the per-hour rate
+  before pushing it into :class:`FundingHedgeGlobalState`. The entity
+  only sees the smooth annualised rate.
+* ``accrued_pnl`` is signed and may go negative — that is the whole
+  point of the hedge: under inverted-funding regimes (short crowded)
+  a long-funding position loses money, and that loss must reach the
+  equity curve.
+
+Storage / inheritance note
+--------------------------
+We inherit from :class:`fractal.core.base.entity.BaseEntity` directly
+because the funding-leg has no analog among the existing fractal-defi
+lending / LP / spot bases — it is a pure cashflow accrual with no
+balance-sheet beyond its own PnL.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from fractal.core.base.entity import (
+    BaseEntity,
+    EntityException,
+    GlobalState,
+    InternalState,
+)
+
+
+# Same convention as MorphoEntity / PendlePTEntity: Julian year so the
+# three entities share an annualisation base.
+SECONDS_PER_YEAR: float = 365.25 * 24 * 3600
+
+
+@dataclass
+class FundingHedgeGlobalState(GlobalState):
+    """Market context for a perpetual-funding carry leg.
+
+    Attributes:
+        funding_rate: Annualised funding rate in decimal (``0.10`` =
+            10% APR). Hyperliquid quotes a per-hour funding rate; the
+            loader multiplies by ``24 * 365.25`` before populating this
+            field, so the entity sees a smooth annualised rate.
+        timestamp_seconds: Unix epoch seconds of the observation. The
+            strategy populates this from ``Observation.timestamp`` so
+            :meth:`FundingHedgeEntity.update_state` can compute
+            ``dt`` between successive updates.
+    """
+
+    funding_rate: float = 0.0
+    timestamp_seconds: float = 0.0
+
+
+@dataclass
+class FundingHedgeInternalState(InternalState):
+    """Position state inside the funding-rate hedge leg.
+
+    Attributes:
+        notional: Current long-funding-rate exposure size in USDC.
+            Set by :meth:`FundingHedgeEntity.action_deposit` /
+            :meth:`FundingHedgeEntity.action_withdraw`.
+        accrued_pnl: Running PnL accrued from funding payments, in
+            USDC. Signed: positive under favourable funding for the
+            configured side, negative otherwise. Persists through
+            ``action_withdraw`` (realised PnL is *not* unwound by
+            closing notional).
+        last_timestamp: Unix epoch seconds of the last observation.
+            ``None`` until the first :meth:`FundingHedgeEntity.update_state`
+            call; thereafter the entity accrues PnL over
+            ``timestamp_seconds - last_timestamp``.
+    """
+
+    notional: float = 0.0
+    accrued_pnl: float = 0.0
+    last_timestamp: float | None = None
+
+
+@dataclass
+class FundingHedgeConfig:
+    """Configuration for the funding-rate hedge entity.
+
+    Attributes:
+        direction: ``"long"`` (default) means the position *receives*
+            funding when ``funding_rate > 0`` — the side a Boros
+            funding-token holder takes. ``"short"`` flips the sign:
+            the position *pays* funding when the rate is positive.
+            Used in tests to flip the carry leg side; in the live
+            strategy we always hold long-funding against PT carry.
+    """
+
+    direction: Literal["long", "short"] = "long"
+
+
+class FundingHedgeEntity(
+    BaseEntity[FundingHedgeGlobalState, FundingHedgeInternalState]
+):
+    """Perpetual-funding-rate carry leg.
+
+    Notional unit: USDC. The entity tracks a notional exposure size
+    and an accrued PnL stream; its equity contribution to the loop's
+    NAV is exactly :attr:`accrued_pnl` (no cash leg held).
+    """
+
+    _internal_state: FundingHedgeInternalState
+    _global_state: FundingHedgeGlobalState
+
+    def __init__(self, config: FundingHedgeConfig | None = None) -> None:
+        self._config = config or FundingHedgeConfig()
+        super().__init__()
+
+    def _initialize_states(self) -> None:
+        self._global_state = FundingHedgeGlobalState()
+        self._internal_state = FundingHedgeInternalState()
+
+    # ------------------------------------------------------------------
+    # Time evolution
+    # ------------------------------------------------------------------
+
+    def update_state(self, state: FundingHedgeGlobalState) -> None:
+        """Apply new market context and accrue funding PnL.
+
+        Flow:
+            1. On the first call (``last_timestamp is None``) we cannot
+               compute ``dt``, so we simply store the new state and the
+               timestamp — no accrual happens yet. This matches the
+               first-observation convention used by :class:`MorphoEntity`.
+            2. On subsequent calls we accrue
+               ``s * notional * funding_rate * dt_years`` into
+               ``accrued_pnl``, where ``s = +1`` for ``direction="long"``
+               and ``s = -1`` for ``direction="short"``.
+
+        The accrual uses *current* ``notional`` — deposits / withdraws
+        applied between observations affect only PnL from the next step
+        onward, which mirrors how a real perp position accrues on its
+        live notional at each funding interval.
+        """
+        if self._internal_state.last_timestamp is not None:
+            dt_years = (
+                state.timestamp_seconds - self._internal_state.last_timestamp
+            ) / SECONDS_PER_YEAR
+            sign = 1.0 if self._config.direction == "long" else -1.0
+            self._internal_state.accrued_pnl += (
+                sign
+                * self._internal_state.notional
+                * state.funding_rate
+                * dt_years
+            )
+        self._internal_state.last_timestamp = state.timestamp_seconds
+        self._global_state = state
+
+    # ------------------------------------------------------------------
+    # Derived quantities
+    # ------------------------------------------------------------------
+
+    @property
+    def balance(self) -> float:
+        """Equity contribution of the hedge leg in USDC.
+
+        The entity holds no cash leg of its own (the delta-hedge offset
+        is assumed perfect and lives outside this entity, by design —
+        see module docstring). Its equity contribution to the loop's
+        NAV is therefore exactly the realised + unrealised funding PnL.
+        """
+        return self._internal_state.accrued_pnl
+
+    # ------------------------------------------------------------------
+    # Action methods
+    # ------------------------------------------------------------------
+
+    def action_deposit(self, amount_in_notional: float) -> None:
+        """Open or extend the funding-rate position by ``amount_in_notional`` USDC.
+
+        Note we do not track a cash balance — ``amount_in_notional`` is
+        the size of the funding-leg notional being added, not a USDC
+        deposit. The implicit assumption is that the delta-neutral
+        offset (spot / futures) is funded outside this entity.
+        """
+        if amount_in_notional < 0:
+            raise EntityException(
+                "action_deposit: amount must be non-negative, "
+                f"got {amount_in_notional}"
+            )
+        self._internal_state.notional += amount_in_notional
+
+    def action_withdraw(self, amount_in_notional: float) -> None:
+        """Close or reduce the notional by ``amount_in_notional`` USDC.
+
+        Realised PnL stays in :attr:`accrued_pnl` — closing the
+        position does *not* unwind past funding payments, just as a
+        perp close does not claw back collected funding.
+        """
+        if amount_in_notional < 0:
+            raise EntityException(
+                "action_withdraw: amount must be non-negative, "
+                f"got {amount_in_notional}"
+            )
+        if amount_in_notional > self._internal_state.notional:
+            raise EntityException(
+                f"action_withdraw: requested {amount_in_notional} but only "
+                f"{self._internal_state.notional} notional held"
+            )
+        self._internal_state.notional -= amount_in_notional

--- a/fractal/core/entities/protocols/funding_hedge.py
+++ b/fractal/core/entities/protocols/funding_hedge.py
@@ -1,60 +1,5 @@
-"""Funding-rate hedge entity — Session 6.
-
-A *funding-rate carry* leg: a notional long (or short) position whose
-PnL stream is the cumulative perpetual-funding cashflow,
-
-.. math::
-
-    \\Delta\\text{PnL} = s \\cdot N \\cdot r_f \\cdot \\Delta t,
-
-where :math:`N` is the notional, :math:`r_f` is the annualised funding
-rate, :math:`\\Delta t` is in years, and :math:`s \\in \\{+1, -1\\}` is
-the side sign (``+1`` for the long-funding side that *receives* funding
-when the rate is positive).
-
-Why this matters for the PT-sUSDe loop
---------------------------------------
-The PT-sUSDe collateral pays a fixed yield (the PT discount unwinding
-to par at expiry), but the *implied yield* market — the price at which
-new PT trades — can drift between deposit and exit. That drift mirrors
-the perpetual-funding regime for sUSDe-style assets: the same demand
-for delta-neutral USD carry that drives Pendle's implied yield is what
-drives perp funding on hyperliquid USDe / sUSDe pairs. A long-funding
-position therefore acts as a partial hedge on implied-yield risk.
-
-Pendle's *Boros* product tokenises exactly this leg (a tradable claim
-on a funding-rate stream); for our backtest we model the stream
-directly rather than wrapping it in a token, since the position is
-held passively and never traded out into a token-market secondary.
-
-Scope / non-goals
------------------
-* No price exposure is modelled. This is purely the carry abstraction
-  — the funding-leg PnL stream, decoupled from the underlying mark.
-  In production we'd close the delta with a spot or futures offset; in
-  the backtest we assume that hedge is perfect and free, which is the
-  standard idealisation for funding-rate carry research.
-* No funding-payment cadence is enforced. Hyperliquid funds hourly,
-  but the loader is responsible for *annualising* the per-hour rate
-  before pushing it into :class:`FundingHedgeGlobalState`. The entity
-  only sees the smooth annualised rate.
-* ``accrued_pnl`` is signed and may go negative — that is the whole
-  point of the hedge: under inverted-funding regimes (short crowded)
-  a long-funding position loses money, and that loss must reach the
-  equity curve.
-
-Storage / inheritance note
---------------------------
-We inherit from :class:`fractal.core.base.entity.BaseEntity` directly
-because the funding-leg has no analog among the existing fractal-defi
-lending / LP / spot bases — it is a pure cashflow accrual with no
-balance-sheet beyond its own PnL.
-"""
-
-from __future__ import annotations
-
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Optional
 
 from fractal.core.base.entity import (
     BaseEntity,
@@ -109,7 +54,10 @@ class FundingHedgeInternalState(InternalState):
 
     notional: float = 0.0
     accrued_pnl: float = 0.0
-    last_timestamp: float | None = None
+    last_timestamp: Optional[float] = None
+
+
+_ALLOWED_DIRECTIONS = ("long", "short")
 
 
 @dataclass
@@ -121,8 +69,8 @@ class FundingHedgeConfig:
             funding when ``funding_rate > 0`` — the side a Boros
             funding-token holder takes. ``"short"`` flips the sign:
             the position *pays* funding when the rate is positive.
-            Used in tests to flip the carry leg side; in the live
-            strategy we always hold long-funding against PT carry.
+            Any other value is rejected by :class:`FundingHedgeEntity`
+            at construction.
     """
 
     direction: Literal["long", "short"] = "long"
@@ -141,8 +89,14 @@ class FundingHedgeEntity(
     _internal_state: FundingHedgeInternalState
     _global_state: FundingHedgeGlobalState
 
-    def __init__(self, config: FundingHedgeConfig | None = None) -> None:
-        self._config = config or FundingHedgeConfig()
+    def __init__(self, config: Optional[FundingHedgeConfig] = None) -> None:
+        cfg = config or FundingHedgeConfig()
+        if cfg.direction not in _ALLOWED_DIRECTIONS:
+            raise EntityException(
+                f"FundingHedgeConfig.direction must be one of "
+                f"{_ALLOWED_DIRECTIONS}, got {cfg.direction!r}"
+            )
+        self._config = cfg
         super().__init__()
 
     def _initialize_states(self) -> None:

--- a/fractal/core/entities/protocols/morpho.py
+++ b/fractal/core/entities/protocols/morpho.py
@@ -1,0 +1,318 @@
+"""Morpho isolated-market lending entity — Session 2.
+
+Morpho Blue exposes one isolated market per (collateral, loan) pair.
+For our strategy the relevant market is **PT-sUSDe → USDC**:
+deposit PT as collateral, borrow USDC against it, with a fixed
+liquidation loan-to-value (LLTV) parameter set per market (typically
+0.86 or 0.915 for PT collateral).
+
+This entity is intentionally close in shape to ``fractal.core.entities.protocols.aave.AaveEntity``
+(borrowed style, dropped the ``collateral_is_volatile`` knob since our
+collateral is PT and direction is fixed: collateral = PT, debt = USDC).
+
+* ``GlobalState`` — collateral price (PT mark in USDC), debt price (USDC = 1),
+  borrowing rate, utilization, observation timestamp.
+* ``InternalState`` — collateral amount (PT face), debt amount (USDC),
+  last accrual timestamp, liquidation flag.
+* Actions:
+  - ``action_deposit`` — add PT collateral (in face units).
+  - ``action_withdraw`` — remove PT collateral.
+  - ``action_borrow`` — draw USDC against collateral.
+  - ``action_repay`` — pay back USDC debt.
+
+Session 2 mechanics:
+    * ``update_state`` accrues debt at ``borrowing_rate * dt`` between
+      successive observations (continuous-compounding approximated by a
+      single per-step multiplier — close enough at our 1h/1d granularity).
+    * ``action_withdraw`` and ``action_borrow`` reject mutations that
+      would push ``ltv`` above the market LLTV. Failed actions revert
+      the partial mutation so the entity never holds half-applied state.
+    * Once an observation pushes ``ltv > lltv`` (e.g. via a collateral
+      price drop), the entity sets ``is_liquidated = True`` and every
+      subsequent action raises. Realistic seizure/penalty modeling is
+      deferred to Session 5; the flag is enough for strategy logic.
+
+We deliberately do NOT accrue a "supplier" yield on the collateral side:
+the collateral is PT face amount, not a yield-bearing deposit. PT pays
+off via its price climbing to 1 at expiry — that effect lives on
+``MorphoGlobalState.collateral_price``, not on the internal balance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fractal.core.base.entity import (
+    EntityException,
+    GlobalState,
+    InternalState,
+)
+from fractal.core.entities.base.lending import BaseLendingEntity
+
+
+# Annualization base for rate accrual. Matches the convention used by
+# Morpho IRMs and most DeFi rate feeds (Julian year, 365.25 days).
+SECONDS_PER_YEAR: float = 365.25 * 24 * 3600
+
+
+@dataclass
+class MorphoGlobalState(GlobalState):
+    """Market context for a single Morpho isolated market.
+
+    Field naming mirrors AaveGlobalState so a strategy can swap one
+    lending backend for another without rewriting predict logic.
+
+    Attributes:
+        collateral_price: USDC value of one unit of collateral (= PT mark price).
+        debt_price: USDC value of one unit of debt asset. For USDC debt: 1.0.
+        lending_rate: Per-step interest credited to collateral. Zero for
+            Morpho's PT markets — PT does not earn supplier yield.
+        borrowing_rate: Annualized interest charged on debt. Derived from
+            Morpho IRM (interest-rate model) on each step; accrued inside
+            :meth:`MorphoEntity.update_state` against ``dt``.
+        utilization: Fraction of supplied debt asset currently borrowed.
+            Drives ``borrowing_rate`` through the IRM; we expose it for
+            risk monitoring (rate spikes occur at high utilization).
+        timestamp_seconds: Unix epoch seconds of the observation. The
+            strategy populates this from ``Observation.timestamp`` so the
+            entity can compute ``dt`` between successive updates.
+    """
+
+    collateral_price: float = 0.0
+    debt_price: float = 1.0
+    lending_rate: float = 0.0
+    borrowing_rate: float = 0.0
+    utilization: float = 0.0
+    timestamp_seconds: float = 0.0
+
+
+@dataclass
+class MorphoInternalState(InternalState):
+    """Position state inside the Morpho market.
+
+    Attributes:
+        collateral: PT collateral amount in face units.
+        debt: USDC debt amount (compounds via ``borrowing_rate`` accrual).
+        last_timestamp: Unix epoch seconds of the last observation. ``None``
+            until the first ``update_state`` call; thereafter the entity
+            accrues debt over ``timestamp_seconds - last_timestamp``.
+        is_liquidated: Flag set when an observation pushes ``ltv > lltv``.
+            Once true, every action raises. Cleared only by re-instantiation.
+    """
+
+    collateral: float = 0.0
+    debt: float = 0.0
+    last_timestamp: float | None = None
+    is_liquidated: bool = False
+
+
+@dataclass
+class MorphoConfig:
+    """Configuration for a Morpho lending market.
+
+    Attributes:
+        market_id: Morpho's 32-byte market identifier (hex string).
+            Informational at backtest level.
+        lltv: Liquidation loan-to-value threshold for this market.
+            When ``ltv > lltv`` the position is liquidatable.
+            Typical Morpho PT markets: 0.86 or 0.915.
+        liquidation_penalty: Bonus paid to liquidators on seized collateral.
+            Typical Morpho: 0.05–0.075. Used in Session 5 for realistic
+            liquidation modeling (seizure at penalty); Session 2 only
+            flags the position.
+    """
+
+    market_id: str = "0x" + "00" * 32
+    lltv: float = 0.86
+    liquidation_penalty: float = 0.05
+
+
+class MorphoEntity(BaseLendingEntity):
+    """Morpho isolated market: PT-collateral → USDC-debt.
+
+    Notional unit: USDC. The entity holds collateral on the protocol
+    side and tracks accrued debt; the user-visible "equity" is
+    ``collateral_value - debt`` in USDC.
+    """
+
+    _internal_state: MorphoInternalState
+    _global_state: MorphoGlobalState
+
+    def __init__(self, config: MorphoConfig | None = None) -> None:
+        self._config = config or MorphoConfig()
+        super().__init__()
+
+    def _initialize_states(self) -> None:
+        self._global_state = MorphoGlobalState()
+        self._internal_state = MorphoInternalState()
+
+    def update_state(self, state: MorphoGlobalState) -> None:
+        """Apply new market context and accrue debt.
+
+        Flow:
+            1. On the first call (``last_timestamp is None``) we cannot
+               compute ``dt``, so we simply store the new state and the
+               timestamp — no accrual happens yet.
+            2. On subsequent calls we accrue debt by
+               ``debt *= 1 + borrowing_rate * dt_years`` using the
+               *previously stored* borrowing rate-equivalent — here we
+               use ``state.borrowing_rate`` directly because the IRM
+               provides a forward-looking rate for the next interval at
+               the start of that interval. (For backtest granularity
+               1h/1d this is indistinguishable from end-of-step accrual.)
+            3. After accrual, if ``ltv > lltv`` we flag the position as
+               liquidated. The flag latches: subsequent actions raise.
+        """
+        if self._internal_state.last_timestamp is not None:
+            dt_years = (
+                state.timestamp_seconds - self._internal_state.last_timestamp
+            ) / SECONDS_PER_YEAR
+            self._internal_state.debt *= 1.0 + state.borrowing_rate * dt_years
+        self._internal_state.last_timestamp = state.timestamp_seconds
+        self._global_state = state
+        if self.ltv > self._config.lltv:
+            self._internal_state.is_liquidated = True
+
+    # ------------------------------------------------------------------
+    # Derived quantities. Available immediately (no Session 2 dependency).
+    # ------------------------------------------------------------------
+
+    @property
+    def collateral_value(self) -> float:
+        """Collateral mark-to-market in USDC."""
+        return (
+            self._internal_state.collateral * self._global_state.collateral_price
+        )
+
+    @property
+    def debt_value(self) -> float:
+        """Debt mark-to-market in USDC. For USDC debt this equals ``debt``."""
+        return self._internal_state.debt * self._global_state.debt_price
+
+    @property
+    def ltv(self) -> float:
+        """Current loan-to-value ratio.
+
+        Returns 0.0 when collateral is zero (debt should also be zero by
+        invariant; if not, the position is already insolvent — Session 2
+        will treat that case as ``ltv = +inf`` via a separate check).
+        """
+        cv = self.collateral_value
+        if cv <= 0:
+            return 0.0
+        return self.debt_value / cv
+
+    @property
+    def health_factor(self) -> float:
+        """Distance to liquidation. >1 = safe, ≤1 = liquidatable.
+
+        Defined as ``lltv / ltv`` to match the standard DeFi convention
+        (Aave health factor formula, modulo small differences in how
+        each protocol expresses the liquidation threshold).
+        """
+        cur_ltv = self.ltv
+        if cur_ltv == 0:
+            return float("inf")
+        return self._config.lltv / cur_ltv
+
+    @property
+    def balance(self) -> float:
+        """Equity in USDC = collateral_value - debt_value."""
+        return self.collateral_value - self.debt_value
+
+    @property
+    def is_liquidated(self) -> bool:
+        """Whether the position has been flagged as liquidatable.
+
+        Set by :meth:`update_state` whenever the post-update LTV exceeds
+        the market LLTV. Latching: once true, no action can clear it.
+        """
+        return self._internal_state.is_liquidated
+
+    # ------------------------------------------------------------------
+    # Action methods. All reject when ``is_liquidated`` is set.
+    # ``withdraw`` and ``borrow`` additionally enforce post-mutation LLTV.
+    # ------------------------------------------------------------------
+
+    def _require_active(self, action_name: str) -> None:
+        """Raise if the position has already been liquidated."""
+        if self._internal_state.is_liquidated:
+            raise EntityException(
+                "entity is liquidated, no further actions allowed "
+                f"(rejected {action_name})"
+            )
+
+    def action_deposit(self, amount_in_notional: float) -> None:
+        """Add PT collateral (notional amount is in PT face units).
+
+        Always reduces LTV (or leaves it unchanged at zero debt), so no
+        LLTV check is needed.
+        """
+        self._require_active("action_deposit")
+        if amount_in_notional < 0:
+            raise EntityException(
+                f"action_deposit: amount must be non-negative, got {amount_in_notional}"
+            )
+        self._internal_state.collateral += amount_in_notional
+
+    def action_withdraw(self, amount_in_notional: float) -> None:
+        """Remove PT collateral (in face units).
+
+        After the mutation we verify ``ltv <= lltv``. If the post-state
+        is unsafe the collateral is restored and the call raises — the
+        entity never holds half-applied state.
+        """
+        self._require_active("action_withdraw")
+        if amount_in_notional < 0:
+            raise EntityException(
+                f"action_withdraw: amount must be non-negative, got {amount_in_notional}"
+            )
+        if amount_in_notional > self._internal_state.collateral:
+            raise EntityException(
+                f"action_withdraw: requested {amount_in_notional} but only "
+                f"{self._internal_state.collateral} collateral held"
+            )
+        self._internal_state.collateral -= amount_in_notional
+        if self.ltv > self._config.lltv:
+            self._internal_state.collateral += amount_in_notional
+            raise EntityException(
+                f"action_withdraw: would push ltv={self.ltv:.6f} above "
+                f"lltv={self._config.lltv:.6f}"
+            )
+
+    def action_borrow(self, amount_in_notional: float) -> None:
+        """Draw USDC against collateral.
+
+        After the mutation we verify ``ltv <= lltv``. If the post-state
+        is unsafe the debt is rolled back and the call raises.
+        """
+        self._require_active("action_borrow")
+        if amount_in_notional < 0:
+            raise EntityException(
+                f"action_borrow: amount must be non-negative, got {amount_in_notional}"
+            )
+        self._internal_state.debt += amount_in_notional
+        if self.ltv > self._config.lltv:
+            self._internal_state.debt -= amount_in_notional
+            raise EntityException(
+                f"action_borrow: would push ltv={self.ltv:.6f} above "
+                f"lltv={self._config.lltv:.6f}"
+            )
+
+    def action_repay(self, amount_in_notional: float) -> None:
+        """Pay back USDC debt.
+
+        Always reduces LTV (or leaves it unchanged), so no LLTV check
+        is needed.
+        """
+        self._require_active("action_repay")
+        if amount_in_notional < 0:
+            raise EntityException(
+                f"action_repay: amount must be non-negative, got {amount_in_notional}"
+            )
+        if amount_in_notional > self._internal_state.debt:
+            raise EntityException(
+                f"action_repay: requested {amount_in_notional} but only "
+                f"{self._internal_state.debt} debt outstanding"
+            )
+        self._internal_state.debt -= amount_in_notional

--- a/fractal/core/entities/protocols/morpho.py
+++ b/fractal/core/entities/protocols/morpho.py
@@ -1,46 +1,5 @@
-"""Morpho isolated-market lending entity — Session 2.
-
-Morpho Blue exposes one isolated market per (collateral, loan) pair.
-For our strategy the relevant market is **PT-sUSDe → USDC**:
-deposit PT as collateral, borrow USDC against it, with a fixed
-liquidation loan-to-value (LLTV) parameter set per market (typically
-0.86 or 0.915 for PT collateral).
-
-This entity is intentionally close in shape to ``fractal.core.entities.protocols.aave.AaveEntity``
-(borrowed style, dropped the ``collateral_is_volatile`` knob since our
-collateral is PT and direction is fixed: collateral = PT, debt = USDC).
-
-* ``GlobalState`` — collateral price (PT mark in USDC), debt price (USDC = 1),
-  borrowing rate, utilization, observation timestamp.
-* ``InternalState`` — collateral amount (PT face), debt amount (USDC),
-  last accrual timestamp, liquidation flag.
-* Actions:
-  - ``action_deposit`` — add PT collateral (in face units).
-  - ``action_withdraw`` — remove PT collateral.
-  - ``action_borrow`` — draw USDC against collateral.
-  - ``action_repay`` — pay back USDC debt.
-
-Session 2 mechanics:
-    * ``update_state`` accrues debt at ``borrowing_rate * dt`` between
-      successive observations (continuous-compounding approximated by a
-      single per-step multiplier — close enough at our 1h/1d granularity).
-    * ``action_withdraw`` and ``action_borrow`` reject mutations that
-      would push ``ltv`` above the market LLTV. Failed actions revert
-      the partial mutation so the entity never holds half-applied state.
-    * Once an observation pushes ``ltv > lltv`` (e.g. via a collateral
-      price drop), the entity sets ``is_liquidated = True`` and every
-      subsequent action raises. Realistic seizure/penalty modeling is
-      deferred to Session 5; the flag is enough for strategy logic.
-
-We deliberately do NOT accrue a "supplier" yield on the collateral side:
-the collateral is PT face amount, not a yield-bearing deposit. PT pays
-off via its price climbing to 1 at expiry — that effect lives on
-``MorphoGlobalState.collateral_price``, not on the internal balance.
-"""
-
-from __future__ import annotations
-
 from dataclasses import dataclass
+from typing import Optional
 
 from fractal.core.base.entity import (
     EntityException,
@@ -102,7 +61,7 @@ class MorphoInternalState(InternalState):
 
     collateral: float = 0.0
     debt: float = 0.0
-    last_timestamp: float | None = None
+    last_timestamp: Optional[float] = None
     is_liquidated: bool = False
 
 
@@ -113,13 +72,14 @@ class MorphoConfig:
     Attributes:
         market_id: Morpho's 32-byte market identifier (hex string).
             Informational at backtest level.
-        lltv: Liquidation loan-to-value threshold for this market.
-            When ``ltv > lltv`` the position is liquidatable.
-            Typical Morpho PT markets: 0.86 or 0.915.
-        liquidation_penalty: Bonus paid to liquidators on seized collateral.
-            Typical Morpho: 0.05–0.075. Used in Session 5 for realistic
-            liquidation modeling (seizure at penalty); Session 2 only
-            flags the position.
+        lltv: Liquidation loan-to-value threshold for this market,
+            in ``(0, 1]``. When ``ltv > lltv`` the position is
+            liquidatable. Typical Morpho PT markets: 0.86 or 0.915.
+            Validated by :class:`MorphoEntity.__init__`.
+        liquidation_penalty: Bonus paid to liquidators on seized
+            collateral. Typical Morpho: 0.05–0.075. Reserved for future
+            liquidation-penalty modelling; the entity only flags
+            ``is_liquidated`` today.
     """
 
     market_id: str = "0x" + "00" * 32
@@ -138,8 +98,18 @@ class MorphoEntity(BaseLendingEntity):
     _internal_state: MorphoInternalState
     _global_state: MorphoGlobalState
 
-    def __init__(self, config: MorphoConfig | None = None) -> None:
-        self._config = config or MorphoConfig()
+    def __init__(self, config: Optional[MorphoConfig] = None) -> None:
+        cfg = config or MorphoConfig()
+        if not 0.0 < cfg.lltv <= 1.0:
+            raise EntityException(
+                f"MorphoConfig.lltv must be in (0, 1], got {cfg.lltv!r}"
+            )
+        if cfg.liquidation_penalty < 0.0:
+            raise EntityException(
+                "MorphoConfig.liquidation_penalty must be non-negative, "
+                f"got {cfg.liquidation_penalty!r}"
+            )
+        self._config = cfg
         super().__init__()
 
     def _initialize_states(self) -> None:
@@ -158,8 +128,8 @@ class MorphoEntity(BaseLendingEntity):
                *previously stored* borrowing rate-equivalent — here we
                use ``state.borrowing_rate`` directly because the IRM
                provides a forward-looking rate for the next interval at
-               the start of that interval. (For backtest granularity
-               1h/1d this is indistinguishable from end-of-step accrual.)
+               the start of that interval. (At 1h / 1d granularity this
+               is indistinguishable from end-of-step accrual.)
             3. After accrual, if ``ltv > lltv`` we flag the position as
                liquidated. The flag latches: subsequent actions raise.
         """
@@ -193,13 +163,15 @@ class MorphoEntity(BaseLendingEntity):
     def ltv(self) -> float:
         """Current loan-to-value ratio.
 
-        Returns 0.0 when collateral is zero (debt should also be zero by
-        invariant; if not, the position is already insolvent — Session 2
-        will treat that case as ``ltv = +inf`` via a separate check).
+        * Both legs zero → ``0.0`` (well-defined, "no position").
+        * Collateral non-positive but debt positive → ``+inf``
+          (insolvent: any LLTV check fails, latching the liquidation
+          flag on the next ``update_state``).
+        * Otherwise → ``debt_value / collateral_value``.
         """
         cv = self.collateral_value
         if cv <= 0:
-            return 0.0
+            return float("inf") if self.debt_value > 0 else 0.0
         return self.debt_value / cv
 
     @property

--- a/fractal/core/entities/protocols/pendle_pt.py
+++ b/fractal/core/entities/protocols/pendle_pt.py
@@ -1,82 +1,6 @@
-"""Pendle Principal Token (PT) entity — Session 2 math.
-
-A PT is a transferable claim on one unit of the underlying SY
-(standardized yield token, e.g. sUSDe) redeemable 1:1 at expiry.
-Before expiry, PT trades at a discount on Pendle's bespoke AMM; the
-discount is the *implied yield* the market is currently pricing.
-
-This entity tracks one PT position on a single (market, expiry) pair.
-
-* ``GlobalState`` — current PT mark price, implied yield, seconds-to-expiry.
-* ``InternalState`` — PT face amount held, USDC cash leftover.
-* Actions:
-  - ``action_deposit`` — accept USDC into cash.
-  - ``action_buy_pt`` — swap USDC -> PT through the Pendle AMM.
-  - ``action_sell_pt`` — swap PT -> USDC (used for early exit / unwind).
-  - ``action_redeem`` — redeem PT 1:1 for the underlying at/after expiry.
-  - ``action_withdraw`` — return USDC cash to the caller.
-
-Session 2 modelling choices
----------------------------
-PT pricing.
-    Pendle's actual AMM uses a logarithmic SY/PT curve parameterised by
-    a scalar root and an anchor implied rate; replicating that in a
-    research backtest gives us false precision (we lack the per-block
-    pool reserves). Instead we treat ``pt_price`` as a function of the
-    quoted implied yield and time-to-expiry. Two parametric forms are
-    exposed via ``pricing_mode``:
-
-    * ``"linear"`` (default) — :math:`P_{PT} = 1 - r_{impl}\\,\\tau`,
-      clamped to :math:`[0, 1]`. Cheap, monotone, exact at expiry.
-    * ``"exponential"`` — :math:`P_{PT} = e^{-r_{impl}\\,\\tau}`,
-      continuous-compounding analogue. Closer to a zero-coupon bond
-      and what Pendle's own UI displays for "fixed yield".
-
-    For first-order analysis the two agree to within
-    :math:`O((r\\tau)^2)` (Taylor): a 14% APY one-year PT differs by
-    ~1.0 cent between the two forms, well below sampling noise.
-
-Real-data path (``derive_pt_price=False``, default).
-    When backtesting against historical Pendle quotes the caller passes
-    the observed ``pt_price`` straight into ``update_state``; we trust
-    that price and only cache ``implied_yield`` for reporting. This is
-    the production path.
-
-Stress / scenario path (``derive_pt_price=True``).
-    When projecting forward without quote data (e.g. "what if APY drops
-    to 8% by week 3?") we let the entity recompute ``pt_price`` from
-    the passed implied yield and time-to-expiry under ``pricing_mode``.
-
-AMM swaps.
-    Pendle pools quote a price plus per-pool fee and incur slippage in
-    the size of the swap relative to the pool. We model this as:
-
-    .. math::
-
-        \\mathit{slip} = \\sigma \\cdot \\frac{\\text{trade size}}
-                                              {\\text{pool liquidity}}
-
-    where :math:`\\sigma` is :attr:`PendlePTConfig.slippage_factor`.
-    A swap consuming the full pool incurs :math:`\\sigma` (50% by
-    default) of mid-price impact — a deliberately conservative sanity
-    scaling, since real Pendle slippage is concave but we only need
-    monotone-in-size for backtest realism. Fees are charged on the
-    notional input side and slippage moves the effective execution
-    price against the trader.
-
-Storage / inheritance note.
-    We use ``fractal.core.base.entity.BaseEntity`` directly because no
-    existing fractal-defi base captures "fixed-yield discount bond" —
-    the existing spot / LP / lending / perp bases assume different
-    mechanics. If the YT entity (variant 3) later materialises with
-    enough overlap we'll extract a ``BaseDiscountBondEntity``.
-"""
-
-from __future__ import annotations
-
 import math
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Optional
 
 from fractal.core.base.entity import (
     BaseEntity,
@@ -149,11 +73,12 @@ class PendlePTGlobalState(GlobalState):
             USDC equivalent. Used to estimate slippage on swaps.
         sy_price_in_usdc: Price of 1 unit of the underlying SY token
             (sUSDe, weETH, USDe, …) in USDC. Used by ``action_redeem``
-            to convert PT face → USDC at expiry. Defaults to 1.0 so
-            existing tests behave identically (SY = stablecoin at peg).
-            When the underlying depegs, this captures the realised loss
-            on the SY-side at expiry — addresses the linear-pricing
-            limitation flagged in the original whitepaper.
+            to convert PT face → USDC at expiry. Defaults to 1.0
+            (SY = stablecoin at peg). When the underlying depegs, this
+            captures the realised loss on the SY-side at expiry. Also
+            consulted by :meth:`PendlePTEntity.balance` after expiry to
+            mark PT face at the prevailing SY/USDC quote, so the NAV
+            curve reflects the depeg before redemption is called.
     """
 
     pt_price: float = 1.0
@@ -211,13 +136,14 @@ class PendlePTEntity(BaseEntity[PendlePTGlobalState, PendlePTInternalState]):
     """Pendle Principal Token position.
 
     Notional unit: USDC. A PT with face amount ``N`` is currently worth
-    ``N * pt_price`` USDC and will redeem for ``N`` USDC at expiry.
+    ``N * pt_price`` USDC and will redeem for ``N * sy_price_in_usdc``
+    USDC at expiry (``sy_price_in_usdc`` defaults to 1.0 = no depeg).
     """
 
     _internal_state: PendlePTInternalState
     _global_state: PendlePTGlobalState
 
-    def __init__(self, config: PendlePTConfig | None = None) -> None:
+    def __init__(self, config: Optional[PendlePTConfig] = None) -> None:
         self._config = config or PendlePTConfig()
         super().__init__()
 
@@ -236,7 +162,8 @@ class PendlePTEntity(BaseEntity[PendlePTGlobalState, PendlePTInternalState]):
 
         1. ``seconds_to_expiry <= 0`` — snap ``pt_price`` to 1.0 and
            ``seconds_to_expiry`` to 0.0 regardless of caller input.
-           PT face-value is constant after expiry by construction.
+           PT face-value is constant in SY units after expiry. The
+           USDC-side mark uses ``sy_price_in_usdc`` from :attr:`balance`.
         2. ``derive_pt_price=True`` — overwrite ``pt_price`` with the
            closed-form from :func:`compute_pt_price`. Used in scenario
            projection.
@@ -255,11 +182,22 @@ class PendlePTEntity(BaseEntity[PendlePTGlobalState, PendlePTInternalState]):
 
     @property
     def balance(self) -> float:
-        """Mark-to-market equity of the entity in USDC."""
-        return (
-            self._internal_state.cash
-            + self._internal_state.pt_face_amount * self._global_state.pt_price
-        )
+        """Mark-to-market equity of the entity in USDC.
+
+        Pre-expiry: ``cash + pt_face_amount * pt_price``. The PT mark
+        already embeds the implied yield, so SY-side depeg is implicit
+        in the AMM quote and we don't multiply by ``sy_price_in_usdc``.
+
+        Post-expiry: ``cash + pt_face_amount * sy_price_in_usdc``. PT
+        face is locked to 1 SY per face, so the USDC mark IS the SY/USDC
+        quote — the depeg flows straight into NAV even before
+        ``action_redeem`` is called.
+        """
+        cash = self._internal_state.cash
+        face = self._internal_state.pt_face_amount
+        if self._global_state.seconds_to_expiry <= 0:
+            return cash + face * self._global_state.sy_price_in_usdc
+        return cash + face * self._global_state.pt_price
 
     # ------------------------------------------------------------------
     # Action methods
@@ -366,7 +304,7 @@ class PendlePTEntity(BaseEntity[PendlePTGlobalState, PendlePTInternalState]):
         :meth:`update_state`). PT redeems 1:1 for SY at expiry; the
         SY → USDC conversion happens at the prevailing SY price
         carried on ``global_state.sy_price_in_usdc`` (defaults to 1.0,
-        which gives the old "stablecoin always at peg" behaviour). When
+        which gives the "stablecoin always at peg" behaviour). When
         the underlying SY has depegged (e.g. USDe in December 2025 or
         eETH in April 2024), redeem realises that loss correctly.
         """

--- a/fractal/core/entities/protocols/pendle_pt.py
+++ b/fractal/core/entities/protocols/pendle_pt.py
@@ -1,0 +1,392 @@
+"""Pendle Principal Token (PT) entity — Session 2 math.
+
+A PT is a transferable claim on one unit of the underlying SY
+(standardized yield token, e.g. sUSDe) redeemable 1:1 at expiry.
+Before expiry, PT trades at a discount on Pendle's bespoke AMM; the
+discount is the *implied yield* the market is currently pricing.
+
+This entity tracks one PT position on a single (market, expiry) pair.
+
+* ``GlobalState`` — current PT mark price, implied yield, seconds-to-expiry.
+* ``InternalState`` — PT face amount held, USDC cash leftover.
+* Actions:
+  - ``action_deposit`` — accept USDC into cash.
+  - ``action_buy_pt`` — swap USDC -> PT through the Pendle AMM.
+  - ``action_sell_pt`` — swap PT -> USDC (used for early exit / unwind).
+  - ``action_redeem`` — redeem PT 1:1 for the underlying at/after expiry.
+  - ``action_withdraw`` — return USDC cash to the caller.
+
+Session 2 modelling choices
+---------------------------
+PT pricing.
+    Pendle's actual AMM uses a logarithmic SY/PT curve parameterised by
+    a scalar root and an anchor implied rate; replicating that in a
+    research backtest gives us false precision (we lack the per-block
+    pool reserves). Instead we treat ``pt_price`` as a function of the
+    quoted implied yield and time-to-expiry. Two parametric forms are
+    exposed via ``pricing_mode``:
+
+    * ``"linear"`` (default) — :math:`P_{PT} = 1 - r_{impl}\\,\\tau`,
+      clamped to :math:`[0, 1]`. Cheap, monotone, exact at expiry.
+    * ``"exponential"`` — :math:`P_{PT} = e^{-r_{impl}\\,\\tau}`,
+      continuous-compounding analogue. Closer to a zero-coupon bond
+      and what Pendle's own UI displays for "fixed yield".
+
+    For first-order analysis the two agree to within
+    :math:`O((r\\tau)^2)` (Taylor): a 14% APY one-year PT differs by
+    ~1.0 cent between the two forms, well below sampling noise.
+
+Real-data path (``derive_pt_price=False``, default).
+    When backtesting against historical Pendle quotes the caller passes
+    the observed ``pt_price`` straight into ``update_state``; we trust
+    that price and only cache ``implied_yield`` for reporting. This is
+    the production path.
+
+Stress / scenario path (``derive_pt_price=True``).
+    When projecting forward without quote data (e.g. "what if APY drops
+    to 8% by week 3?") we let the entity recompute ``pt_price`` from
+    the passed implied yield and time-to-expiry under ``pricing_mode``.
+
+AMM swaps.
+    Pendle pools quote a price plus per-pool fee and incur slippage in
+    the size of the swap relative to the pool. We model this as:
+
+    .. math::
+
+        \\mathit{slip} = \\sigma \\cdot \\frac{\\text{trade size}}
+                                              {\\text{pool liquidity}}
+
+    where :math:`\\sigma` is :attr:`PendlePTConfig.slippage_factor`.
+    A swap consuming the full pool incurs :math:`\\sigma` (50% by
+    default) of mid-price impact — a deliberately conservative sanity
+    scaling, since real Pendle slippage is concave but we only need
+    monotone-in-size for backtest realism. Fees are charged on the
+    notional input side and slippage moves the effective execution
+    price against the trader.
+
+Storage / inheritance note.
+    We use ``fractal.core.base.entity.BaseEntity`` directly because no
+    existing fractal-defi base captures "fixed-yield discount bond" —
+    the existing spot / LP / lending / perp bases assume different
+    mechanics. If the YT entity (variant 3) later materialises with
+    enough overlap we'll extract a ``BaseDiscountBondEntity``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from fractal.core.base.entity import (
+    BaseEntity,
+    EntityException,
+    GlobalState,
+    InternalState,
+)
+
+
+SECONDS_PER_YEAR: float = 365.25 * 24 * 3600
+
+
+def compute_pt_price(
+    implied_yield: float,
+    seconds_to_expiry: float,
+    mode: str = "linear",
+) -> float:
+    """Closed-form PT price from implied yield and time-to-expiry.
+
+    Args:
+        implied_yield: Annualised fixed yield in decimal (0.14 = 14% APY).
+        seconds_to_expiry: Wall-clock seconds remaining until redeem.
+        mode: ``"linear"`` for :math:`1 - r\\,\\tau` (clamped to
+            :math:`[0, 1]`) or ``"exponential"`` for :math:`e^{-r\\,\\tau}`.
+
+    Returns:
+        PT mid-price in USDC. Always 1.0 at/after expiry regardless
+        of ``mode`` or ``implied_yield``.
+
+    Raises:
+        EntityException: If ``mode`` is not one of the supported forms.
+    """
+    if seconds_to_expiry <= 0:
+        return 1.0
+    tau = seconds_to_expiry / SECONDS_PER_YEAR
+    if mode == "linear":
+        price = 1.0 - implied_yield * tau
+        # Clamp: negative implied yields (premium) or absurdly long tau
+        # could push outside [0, 1]; the bond can't.
+        if price < 0.0:
+            return 0.0
+        if price > 1.0:
+            return 1.0
+        return price
+    if mode == "exponential":
+        return math.exp(-implied_yield * tau)
+    raise EntityException(
+        f"compute_pt_price: unsupported mode {mode!r}; "
+        "expected 'linear' or 'exponential'"
+    )
+
+
+@dataclass
+class PendlePTGlobalState(GlobalState):
+    """Market context for a single PT/SY market on a given epoch.
+
+    Attributes:
+        pt_price: Current market price of 1 PT in USDC.
+            Pre-expiry: in :math:`(0, 1]`, monotonically approaching 1.
+            At/after expiry: exactly 1 (constant) in *SY units*; the
+            redeemed USDC value still depends on ``sy_price_in_usdc``.
+        implied_yield: Annualised fixed yield baked into ``pt_price``
+            at the moment of observation, in decimal (0.14 = 14% APY).
+            Convenience only — derivable from ``pt_price`` and
+            ``seconds_to_expiry``; we cache it to avoid recomputing on
+            every step.
+        seconds_to_expiry: Wall-clock seconds remaining until PT redeem
+            unlocks. Drops to 0 at expiry, then stays 0.
+        pool_liquidity: Total liquidity in the PT/SY Pendle pool, in
+            USDC equivalent. Used to estimate slippage on swaps.
+        sy_price_in_usdc: Price of 1 unit of the underlying SY token
+            (sUSDe, weETH, USDe, …) in USDC. Used by ``action_redeem``
+            to convert PT face → USDC at expiry. Defaults to 1.0 so
+            existing tests behave identically (SY = stablecoin at peg).
+            When the underlying depegs, this captures the realised loss
+            on the SY-side at expiry — addresses the linear-pricing
+            limitation flagged in the original whitepaper.
+    """
+
+    pt_price: float = 1.0
+    implied_yield: float = 0.0
+    seconds_to_expiry: float = 0.0
+    pool_liquidity: float = 0.0
+    sy_price_in_usdc: float = 1.0
+
+
+@dataclass
+class PendlePTInternalState(InternalState):
+    """Position state inside the PT entity.
+
+    Attributes:
+        pt_face_amount: Quantity of PT held, in face units
+            (1 face = 1 USDC at expiry).
+        cash: Free USDC sitting in the entity (not yet deployed to PT).
+    """
+
+    pt_face_amount: float = 0.0
+    cash: float = 0.0
+
+
+@dataclass
+class PendlePTConfig:
+    """Configuration for a Pendle PT entity.
+
+    Attributes:
+        market_address: The 20-byte address of the Pendle market.
+            Informational at backtest level; used by loaders to scope
+            historical data.
+        amm_fee_rate: Fee charged by Pendle AMM on PT/SY swaps.
+            Default 0.001 (10 basis points) — Pendle's typical pool fee.
+        slippage_factor: Dimensionless scaling of size-impact: a swap
+            equal to the full pool liquidity moves the effective price
+            by ``slippage_factor`` (default 0.5 = 50%). Lower for deep
+            pools, higher for thin ones.
+        pricing_mode: Parametric form for ``compute_pt_price`` — either
+            ``"linear"`` or ``"exponential"``. Only consulted when
+            ``derive_pt_price`` is true.
+        derive_pt_price: If false (default), ``update_state`` accepts
+            the caller's ``pt_price`` as ground truth — the real-data
+            path. If true, ``update_state`` overwrites ``pt_price``
+            with ``compute_pt_price`` for forward-projection scenarios.
+    """
+
+    market_address: str = "0x0000000000000000000000000000000000000000"
+    amm_fee_rate: float = 0.001
+    slippage_factor: float = 0.5
+    pricing_mode: Literal["linear", "exponential"] = "linear"
+    derive_pt_price: bool = False
+
+
+class PendlePTEntity(BaseEntity[PendlePTGlobalState, PendlePTInternalState]):
+    """Pendle Principal Token position.
+
+    Notional unit: USDC. A PT with face amount ``N`` is currently worth
+    ``N * pt_price`` USDC and will redeem for ``N`` USDC at expiry.
+    """
+
+    _internal_state: PendlePTInternalState
+    _global_state: PendlePTGlobalState
+
+    def __init__(self, config: PendlePTConfig | None = None) -> None:
+        self._config = config or PendlePTConfig()
+        super().__init__()
+
+    def _initialize_states(self) -> None:
+        self._global_state = PendlePTGlobalState()
+        self._internal_state = PendlePTInternalState()
+
+    # ------------------------------------------------------------------
+    # Time evolution
+    # ------------------------------------------------------------------
+
+    def update_state(self, state: PendlePTGlobalState) -> None:
+        """Apply new market context.
+
+        Three branches:
+
+        1. ``seconds_to_expiry <= 0`` — snap ``pt_price`` to 1.0 and
+           ``seconds_to_expiry`` to 0.0 regardless of caller input.
+           PT face-value is constant after expiry by construction.
+        2. ``derive_pt_price=True`` — overwrite ``pt_price`` with the
+           closed-form from :func:`compute_pt_price`. Used in scenario
+           projection.
+        3. Otherwise — accept ``pt_price`` as passed (real-data path).
+        """
+        if state.seconds_to_expiry <= 0:
+            state.pt_price = 1.0
+            state.seconds_to_expiry = 0.0
+        elif self._config.derive_pt_price:
+            state.pt_price = compute_pt_price(
+                state.implied_yield,
+                state.seconds_to_expiry,
+                self._config.pricing_mode,
+            )
+        self._global_state = state
+
+    @property
+    def balance(self) -> float:
+        """Mark-to-market equity of the entity in USDC."""
+        return (
+            self._internal_state.cash
+            + self._internal_state.pt_face_amount * self._global_state.pt_price
+        )
+
+    # ------------------------------------------------------------------
+    # Action methods
+    # ------------------------------------------------------------------
+
+    def action_deposit(self, amount_in_notional: float) -> None:
+        """Add USDC cash to the entity."""
+        if amount_in_notional < 0:
+            raise EntityException(
+                f"action_deposit: amount must be non-negative, got {amount_in_notional}"
+            )
+        self._internal_state.cash += amount_in_notional
+
+    def action_withdraw(self, amount_in_notional: float) -> None:
+        """Remove USDC cash from the entity."""
+        if amount_in_notional < 0:
+            raise EntityException(
+                f"action_withdraw: amount must be non-negative, got {amount_in_notional}"
+            )
+        if amount_in_notional > self._internal_state.cash:
+            raise EntityException(
+                f"action_withdraw: requested {amount_in_notional} but only "
+                f"{self._internal_state.cash} cash available"
+            )
+        self._internal_state.cash -= amount_in_notional
+
+    def action_buy_pt(self, amount_in_notional: float) -> None:
+        """Swap ``amount_in_notional`` USDC for PT through the Pendle AMM.
+
+        Effective price logic:
+
+        * ``effective_in = amount * (1 - amm_fee_rate)`` — fee taken on
+          input USDC.
+        * ``slip = slippage_factor * amount / pool_liquidity`` —
+          size-impact; positive on a buy (price walks up).
+        * ``effective_price = pt_price * (1 + slip)``.
+        * ``pt_received = effective_in / effective_price``.
+        """
+        if amount_in_notional < 0:
+            raise EntityException(
+                f"action_buy_pt: amount must be non-negative, got {amount_in_notional}"
+            )
+        if amount_in_notional > self._internal_state.cash:
+            raise EntityException(
+                f"action_buy_pt: requested {amount_in_notional} but only "
+                f"{self._internal_state.cash} cash available"
+            )
+        pt_price = self._global_state.pt_price
+        if pt_price <= 0:
+            raise EntityException(f"action_buy_pt: invalid pt_price {pt_price}")
+        pool_liquidity = self._global_state.pool_liquidity
+        if pool_liquidity <= 0:
+            raise EntityException(
+                f"action_buy_pt: pool_liquidity must be positive, got {pool_liquidity}"
+            )
+
+        effective_in = amount_in_notional * (1.0 - self._config.amm_fee_rate)
+        slip = self._config.slippage_factor * amount_in_notional / pool_liquidity
+        effective_price = pt_price * (1.0 + slip)
+        pt_received = effective_in / effective_price
+
+        self._internal_state.cash -= amount_in_notional
+        self._internal_state.pt_face_amount += pt_received
+
+    def action_sell_pt(self, amount_in_face: float) -> None:
+        """Swap ``amount_in_face`` PT (face units) for USDC.
+
+        Symmetric to :meth:`action_buy_pt`: slippage now drags the
+        effective price *down* (you sell into the book), and the fee
+        is taken on the USDC leg coming back.
+        """
+        if amount_in_face < 0:
+            raise EntityException(
+                f"action_sell_pt: amount must be non-negative, got {amount_in_face}"
+            )
+        if amount_in_face > self._internal_state.pt_face_amount:
+            raise EntityException(
+                f"action_sell_pt: requested {amount_in_face} but only "
+                f"{self._internal_state.pt_face_amount} PT held"
+            )
+        pt_price = self._global_state.pt_price
+        if pt_price <= 0:
+            raise EntityException(f"action_sell_pt: invalid pt_price {pt_price}")
+        pool_liquidity = self._global_state.pool_liquidity
+        if pool_liquidity <= 0:
+            raise EntityException(
+                f"action_sell_pt: pool_liquidity must be positive, got {pool_liquidity}"
+            )
+
+        slip = self._config.slippage_factor * amount_in_face / pool_liquidity
+        effective_price = pt_price * (1.0 - slip)
+        if effective_price < 0:
+            effective_price = 0.0
+        gross_usdc = amount_in_face * effective_price
+        usdc_received = gross_usdc * (1.0 - self._config.amm_fee_rate)
+
+        self._internal_state.pt_face_amount -= amount_in_face
+        self._internal_state.cash += usdc_received
+
+    def action_redeem(self, amount_in_face: float) -> None:
+        """Redeem PT for the underlying SY at/after expiry.
+
+        Requires ``seconds_to_expiry == 0`` (enforced by
+        :meth:`update_state`). PT redeems 1:1 for SY at expiry; the
+        SY → USDC conversion happens at the prevailing SY price
+        carried on ``global_state.sy_price_in_usdc`` (defaults to 1.0,
+        which gives the old "stablecoin always at peg" behaviour). When
+        the underlying SY has depegged (e.g. USDe in December 2025 or
+        eETH in April 2024), redeem realises that loss correctly.
+        """
+        if amount_in_face < 0:
+            raise EntityException(
+                f"action_redeem: amount must be non-negative, got {amount_in_face}"
+            )
+        if self._global_state.seconds_to_expiry > 0:
+            raise EntityException(
+                f"action_redeem: PT not at expiry yet "
+                f"(seconds_to_expiry={self._global_state.seconds_to_expiry})"
+            )
+        if amount_in_face > self._internal_state.pt_face_amount:
+            raise EntityException(
+                f"action_redeem: requested {amount_in_face} but only "
+                f"{self._internal_state.pt_face_amount} PT held"
+            )
+
+        # Redeem PT → SY 1:1 (Pendle invariant), then SY → USDC at the
+        # prevailing SY market price.
+        sy_price = self._global_state.sy_price_in_usdc
+        self._internal_state.pt_face_amount -= amount_in_face
+        self._internal_state.cash += amount_in_face * sy_price

--- a/fractal/loaders/__init__.py
+++ b/fractal/loaders/__init__.py
@@ -8,6 +8,7 @@ from fractal.loaders.binance import (
     BinancePriceLoader,
     BinanceSpotPriceLoader,
 )
+from fractal.loaders.boros import BorosMarketLoader
 from fractal.loaders.gmx_v1 import GMXV1FundingLoader
 from fractal.loaders.hyperliquid import (  # Pre-1.3.0 alias.
     HyperliquidFundingRatesLoader,
@@ -15,11 +16,16 @@ from fractal.loaders.hyperliquid import (  # Pre-1.3.0 alias.
     HyperliquidPerpsPricesLoader,
     HyperLiquidPerpsPricesLoader,
 )
+from fractal.loaders.morpho import MorphoMarketLoader
+from fractal.loaders.pendle import PendleMarketLoader
 from fractal.loaders.simulations import ConstantFundingsLoader, MonteCarloHourPriceLoader, MonteCarloPriceLoader
 from fractal.loaders.structs import (
+    BorosMarketHistory,
     FundingHistory,
     KlinesHistory,
     LendingHistory,
+    MorphoMarketHistory,
+    PendleMarketHistory,
     PoolHistory,
     PriceHistory,
     RateHistory,
@@ -49,6 +55,12 @@ __all__ = [
     "RateHistory",
     "LendingHistory",
     "KlinesHistory",
+    "PendleMarketHistory",
+    "PendleMarketLoader",
+    "MorphoMarketHistory",
+    "MorphoMarketLoader",
+    "BorosMarketHistory",
+    "BorosMarketLoader",
     "TrajectoryBundle",
     "AaveV2EthereumLoader",
     "AaveV3ArbitrumLoader",

--- a/fractal/loaders/__init__.py
+++ b/fractal/loaders/__init__.py
@@ -18,13 +18,13 @@ from fractal.loaders.hyperliquid import (  # Pre-1.3.0 alias.
 )
 from fractal.loaders.morpho import MorphoMarketLoader
 from fractal.loaders.pendle import PendleMarketLoader
+from fractal.loaders.pendle_ohlcv import PendleOHLCVLoader
 from fractal.loaders.simulations import ConstantFundingsLoader, MonteCarloHourPriceLoader, MonteCarloPriceLoader
 from fractal.loaders.structs import (
     BorosMarketHistory,
     FundingHistory,
     KlinesHistory,
     LendingHistory,
-    MorphoMarketHistory,
     PendleMarketHistory,
     PoolHistory,
     PriceHistory,
@@ -57,7 +57,7 @@ __all__ = [
     "KlinesHistory",
     "PendleMarketHistory",
     "PendleMarketLoader",
-    "MorphoMarketHistory",
+    "PendleOHLCVLoader",
     "MorphoMarketLoader",
     "BorosMarketHistory",
     "BorosMarketLoader",

--- a/fractal/loaders/boros.py
+++ b/fractal/loaders/boros.py
@@ -1,0 +1,186 @@
+"""Pendle Boros market loader.
+
+Boros is Pendle's funding-rate tokenisation layer launched August 2025.
+A Boros market represents a forward on the *average funding rate* of a
+specific perpetual futures market (e.g. Hyperliquid ETH-USDC) up to a
+fixed maturity. Going long a Boros market = receiving funding payments
+between now and maturity; going short = paying.
+
+API
+---
+Public, keyless:
+
+* List markets: ``GET https://api.boros.finance/core/v1/markets``
+  Returns a list of objects with ``marketId``, ``imData.symbol``,
+  ``imData.maturity``, ``metadata.fundingRateSymbol``,
+  ``data.markApr`` (current annualised mark rate), and so on.
+
+* Historical bars: ``GET https://api.boros.finance/core/v1/markets/chart``
+  ``?marketId=<N>&timeFrame=<5m|1h|1d|1w>``. The endpoint **ignores
+  ``from``/``to`` parameters and always returns the most recent ~500
+  bars** (verified empirically May 2026). For longer history we would
+  need to scrape on-chain via ``eth_getLogs`` on the AMM contract —
+  out of scope for the current research project.
+
+Output
+------
+DataFrame indexed by UTC datetime, columns:
+
+* ``mark_apr``         — close mark rate (annualised, decimal).
+* ``observed_funding`` — close observed funding rate (annualised).
+* ``mark_apr_7d_ma``   — 7-day moving average of observed funding.
+* ``mark_apr_30d_ma``  — 30-day moving average of observed funding.
+
+The ``mark_apr`` column is what a long-Boros holder receives in funding
+per unit of time. It is the analogue of
+``funding_rate_annualised`` in the ``FundingHedgeLoader`` (Hyperliquid
+proxy) and can be swapped in directly in any strategy that consumes
+funding-rate observations.
+
+Recent-only coverage is a known limitation. We use the Hyperliquid
+funding-rate loader as a long-history proxy and validate empirically
+on the overlap window that the two series track each other closely.
+See ``scripts/validate_boros_proxy.py``.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+from fractal.loaders.base_loader import Loader, LoaderType
+from fractal.loaders.structs import BorosMarketHistory
+
+BOROS_API_BASE: str = "https://api.boros.finance/core/v1"
+
+_REQUEST_TIMEOUT_S: float = 30.0
+_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "mark_apr",
+    "observed_funding",
+    "mark_apr_7d_ma",
+    "mark_apr_30d_ma",
+)
+
+
+def _to_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+class BorosMarketLoader(Loader):
+    """Recent funding-rate bars for one Boros market.
+
+    Pipeline: ``extract`` issues a single REST GET to the Boros chart
+    endpoint and stashes the JSON in ``self._raw``; ``transform`` parses
+    the bar list into a UTC-indexed DataFrame.
+    """
+
+    def __init__(
+        self,
+        market_id: int,
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        time_frame: str = "1h",
+        api_key: str | None = None,
+        loader_type: LoaderType = LoaderType.CSV,
+    ) -> None:
+        super().__init__(loader_type=loader_type)
+        self.market_id: int = int(market_id)
+        self.start_time: datetime = _to_utc(start_time)
+        self.end_time: datetime = _to_utc(end_time)
+        self.time_frame: str = time_frame
+        self._api_key: str | None = api_key
+        self._raw: dict[str, Any] = {}
+
+    def _cache_key(self) -> str:
+        s = self.start_time.strftime("%Y%m%d")
+        e = self.end_time.strftime("%Y%m%d")
+        return f"market{self.market_id}-{self.time_frame}-{s}-{e}"
+
+    def _url(self) -> str:
+        return f"{BOROS_API_BASE}/markets/chart"
+
+    def _params(self) -> dict[str, Any]:
+        return {"marketId": self.market_id, "timeFrame": self.time_frame}
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def extract(self) -> None:
+        response = requests.get(
+            self._url(),
+            params=self._params(),
+            headers=self._headers(),
+            timeout=_REQUEST_TIMEOUT_S,
+        )
+        response.raise_for_status()
+        payload = response.json() if callable(getattr(response, "json", None)) else {}
+        self._raw = payload if isinstance(payload, dict) else {}
+
+    def transform(self) -> None:
+        if not self._raw:
+            self._data = BorosMarketHistory([], [], [], [], [])
+            return
+        rows = _parse_bars(self._raw)
+        rows = [r for r in rows if self.start_time <= r["dt"] <= self.end_time]
+        if not rows:
+            self._data = BorosMarketHistory([], [], [], [], [])
+            return
+        self._data = BorosMarketHistory(
+            mark_apr=[r["mark_apr"] for r in rows],
+            observed_funding=[r["observed_funding"] for r in rows],
+            mark_apr_7d_ma=[r["mark_apr_7d_ma"] for r in rows],
+            mark_apr_30d_ma=[r["mark_apr_30d_ma"] for r in rows],
+            time=[int(r["dt"].timestamp()) for r in rows],
+        )
+
+    def read(self, with_run: bool = False) -> BorosMarketHistory:
+        if with_run:
+            self.run()
+        else:
+            self._read(self._cache_key())
+        return self._data
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _parse_bars(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Parse Boros chart payload — list of bars under ``results``."""
+    results = payload.get("results") or []
+    if not isinstance(results, list) or not results:
+        return []
+    parsed: list[dict[str, Any]] = []
+    seen_ts: set[int] = set()
+    for row in results:
+        try:
+            epoch = int(row["ts"])
+            mark_apr = float(row.get("c", row.get("mr", 0.0)))
+            observed = float(row.get("u", row.get("ofr", 0.0)))
+            ma7 = float(row.get("b7dmafr", 0.0))
+            ma30 = float(row.get("b30dmafr", 0.0))
+        except (TypeError, ValueError, KeyError):
+            continue
+        if epoch in seen_ts:
+            continue
+        seen_ts.add(epoch)
+        parsed.append(
+            {
+                "dt": datetime.fromtimestamp(epoch, tz=timezone.utc),
+                "mark_apr": mark_apr,
+                "observed_funding": observed,
+                "mark_apr_7d_ma": ma7,
+                "mark_apr_30d_ma": ma30,
+            }
+        )
+    parsed.sort(key=lambda r: r["dt"])
+    return parsed
+
+
+__all__ = ["BorosMarketLoader", "BOROS_API_BASE"]

--- a/fractal/loaders/boros.py
+++ b/fractal/loaders/boros.py
@@ -24,7 +24,7 @@ Public, keyless:
 
 Output
 ------
-DataFrame indexed by UTC datetime, columns:
+:class:`BorosMarketHistory` indexed by UTC datetime with columns:
 
 * ``mark_apr``         — close mark rate (annualised, decimal).
 * ``observed_funding`` — close observed funding rate (annualised).
@@ -32,30 +32,28 @@ DataFrame indexed by UTC datetime, columns:
 * ``mark_apr_30d_ma``  — 30-day moving average of observed funding.
 
 The ``mark_apr`` column is what a long-Boros holder receives in funding
-per unit of time. It is the analogue of
-``funding_rate_annualised`` in the ``FundingHedgeLoader`` (Hyperliquid
-proxy) and can be swapped in directly in any strategy that consumes
-funding-rate observations.
+per unit of time. It is the analogue of the per-hour funding-rate
+loaders (Hyperliquid, Binance) and can be swapped in directly in any
+strategy that consumes funding-rate observations.
 
-Recent-only coverage is a known limitation. We use the Hyperliquid
-funding-rate loader as a long-history proxy and validate empirically
-on the overlap window that the two series track each other closely.
-See ``scripts/validate_boros_proxy.py``.
+Recent-only coverage is a known endpoint limitation, not a loader bug.
+For long-history backtests, calibrate against a per-hour funding feed
+(e.g. :class:`HyperliquidFundingRatesLoader`) on the overlap window.
 """
-from __future__ import annotations
-
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
 
-import requests
+import pandas as pd
 
+from fractal.loaders._http import HttpClient
 from fractal.loaders.base_loader import Loader, LoaderType
 from fractal.loaders.structs import BorosMarketHistory
 
 BOROS_API_BASE: str = "https://api.boros.finance/core/v1"
 
-_REQUEST_TIMEOUT_S: float = 30.0
-_OUTPUT_COLUMNS: tuple[str, ...] = (
+_ALLOWED_TIME_FRAMES: FrozenSet[str] = frozenset({"5m", "1h", "1d", "1w"})
+
+_OUTPUT_COLUMNS: Tuple[str, ...] = (
     "mark_apr",
     "observed_funding",
     "mark_apr_7d_ma",
@@ -73,8 +71,10 @@ class BorosMarketLoader(Loader):
     """Recent funding-rate bars for one Boros market.
 
     Pipeline: ``extract`` issues a single REST GET to the Boros chart
-    endpoint and stashes the JSON in ``self._raw``; ``transform`` parses
-    the bar list into a UTC-indexed DataFrame.
+    endpoint via the shared :class:`HttpClient` (retry + backoff) and
+    stashes the JSON in ``self._raw``; ``transform`` parses the bar
+    list into a typed :class:`BorosMarketHistory`; ``read`` returns the
+    same type on both cache-hit and cache-miss paths.
     """
 
     def __init__(
@@ -84,53 +84,50 @@ class BorosMarketLoader(Loader):
         end_time: datetime,
         *,
         time_frame: str = "1h",
-        api_key: str | None = None,
+        api_key: Optional[str] = None,
         loader_type: LoaderType = LoaderType.CSV,
     ) -> None:
         super().__init__(loader_type=loader_type)
+        if time_frame not in _ALLOWED_TIME_FRAMES:
+            raise ValueError(
+                f"time_frame must be one of {sorted(_ALLOWED_TIME_FRAMES)}, "
+                f"got {time_frame!r}"
+            )
         self.market_id: int = int(market_id)
         self.start_time: datetime = _to_utc(start_time)
         self.end_time: datetime = _to_utc(end_time)
+        if self.end_time < self.start_time:
+            raise ValueError(
+                f"end_time {self.end_time} precedes start_time {self.start_time}"
+            )
         self.time_frame: str = time_frame
-        self._api_key: str | None = api_key
-        self._raw: dict[str, Any] = {}
+        self._api_key: Optional[str] = api_key
+        self._raw: Dict[str, Any] = {}
+        self._http: HttpClient = HttpClient()
 
     def _cache_key(self) -> str:
-        s = self.start_time.strftime("%Y%m%d")
-        e = self.end_time.strftime("%Y%m%d")
+        s = int(self.start_time.timestamp())
+        e = int(self.end_time.timestamp())
         return f"market{self.market_id}-{self.time_frame}-{s}-{e}"
 
     def _url(self) -> str:
         return f"{BOROS_API_BASE}/markets/chart"
 
-    def _params(self) -> dict[str, Any]:
+    def _params(self) -> Dict[str, Any]:
         return {"marketId": self.market_id, "timeFrame": self.time_frame}
 
-    def _headers(self) -> dict[str, str]:
-        headers = {"Accept": "application/json"}
-        if self._api_key:
-            headers["Authorization"] = f"Bearer {self._api_key}"
-        return headers
-
     def extract(self) -> None:
-        response = requests.get(
-            self._url(),
-            params=self._params(),
-            headers=self._headers(),
-            timeout=_REQUEST_TIMEOUT_S,
-        )
-        response.raise_for_status()
-        payload = response.json() if callable(getattr(response, "json", None)) else {}
+        payload = self._http.get(self._url(), params=self._params())
         self._raw = payload if isinstance(payload, dict) else {}
 
     def transform(self) -> None:
         if not self._raw:
-            self._data = BorosMarketHistory([], [], [], [], [])
+            self._data = _empty_history()
             return
         rows = _parse_bars(self._raw)
         rows = [r for r in rows if self.start_time <= r["dt"] <= self.end_time]
         if not rows:
-            self._data = BorosMarketHistory([], [], [], [], [])
+            self._data = _empty_history()
             return
         self._data = BorosMarketHistory(
             mark_apr=[r["mark_apr"] for r in rows],
@@ -141,23 +138,35 @@ class BorosMarketLoader(Loader):
         )
 
     def read(self, with_run: bool = False) -> BorosMarketHistory:
+        """Return the typed ``BorosMarketHistory`` on both cache paths."""
         if with_run:
             self.run()
         else:
             self._read(self._cache_key())
+            self._data = _rebuild_from_cache(self._data)
         return self._data
 
 
 # ---------------------------------------------------------------- helpers
 
 
-def _parse_bars(payload: dict[str, Any]) -> list[dict[str, Any]]:
+def _empty_history() -> BorosMarketHistory:
+    return BorosMarketHistory(
+        mark_apr=[],
+        observed_funding=[],
+        mark_apr_7d_ma=[],
+        mark_apr_30d_ma=[],
+        time=[],
+    )
+
+
+def _parse_bars(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Parse Boros chart payload — list of bars under ``results``."""
     results = payload.get("results") or []
     if not isinstance(results, list) or not results:
         return []
-    parsed: list[dict[str, Any]] = []
-    seen_ts: set[int] = set()
+    parsed: List[Dict[str, Any]] = []
+    seen_ts: Set[int] = set()
     for row in results:
         try:
             epoch = int(row["ts"])
@@ -181,6 +190,32 @@ def _parse_bars(payload: dict[str, Any]) -> list[dict[str, Any]]:
         )
     parsed.sort(key=lambda r: r["dt"])
     return parsed
+
+
+def _rebuild_from_cache(data: Any) -> BorosMarketHistory:
+    """Coerce a cached ``pd.DataFrame`` (or ``BorosMarketHistory``) back to typed form."""
+    if isinstance(data, BorosMarketHistory):
+        return data
+    if data is None or (isinstance(data, pd.DataFrame) and data.empty):
+        return _empty_history()
+    df = data.copy() if isinstance(data, pd.DataFrame) else pd.DataFrame(data)
+    if "time" in df.columns:
+        df["time"] = pd.to_datetime(df["time"], utc=True)
+        df = df.set_index("time").sort_index()
+    idx = pd.to_datetime(df.index, utc=True)
+    if not isinstance(idx, pd.DatetimeIndex):
+        idx = pd.DatetimeIndex(idx)
+    idx.name = "time"
+    for col in _OUTPUT_COLUMNS:
+        if col not in df.columns:
+            df[col] = float("nan")
+    return BorosMarketHistory(
+        mark_apr=df["mark_apr"].to_numpy(),
+        observed_funding=df["observed_funding"].to_numpy(),
+        mark_apr_7d_ma=df["mark_apr_7d_ma"].to_numpy(),
+        mark_apr_30d_ma=df["mark_apr_30d_ma"].to_numpy(),
+        time=idx,
+    )
 
 
 __all__ = ["BorosMarketLoader", "BOROS_API_BASE"]

--- a/fractal/loaders/morpho.py
+++ b/fractal/loaders/morpho.py
@@ -10,41 +10,32 @@ Morpho exposes market data through a keyless GraphQL endpoint at
 window. Each timeseries entry is a ``FloatDataPoint`` of shape
 ``{x: <unix_seconds>, y: <decimal>}``.
 
-The fields we read are already **annualized decimals**:
+The fields we read are already **annualised decimals**:
 
-* ``borrowApy`` — annualized borrow APY paid by debtors. Equivalent to
-  the ``borrowing_rate`` consumed by :class:`MorphoEntity`. Morpho APIs
-  expose this as ``borrowApy`` (compounded view) rather than the raw
-  per-second rate; for backtest granularity the difference between
-  continuous and compounded conventions is < 1 bp at typical rates.
-* ``supplyApy`` — annualized supply APY earned by lenders (informational
-  here — the strategy entity pins ``lending_rate=0`` because Pendle PT
-  collateral does not accrue supplier yield in Morpho).
+* ``borrowApy`` — annualised borrow APY paid by debtors. Equivalent to
+  the ``borrowing_rate`` column of :class:`LendingHistory`.
+* ``supplyApy`` — annualised supply APY earned by lenders. Equivalent
+  to the ``lending_rate`` column of :class:`LendingHistory`.
 * ``utilization`` — fraction of supplied debt asset currently borrowed,
-  in [0, 1]. Drives the IRM and is useful for rate-spike monitoring.
+  in ``[0, 1]``. Optional column of :class:`LendingHistory` populated
+  by this loader (Morpho exposes it; other lending sources may not).
 
 Chains
 ------
-Morpho is deployed on Ethereum mainnet and Arbitrum (plus Base, etc.).
-This loader accepts a chain name and maps it to the API's ``chainId``
-parameter. Add new chains by extending :data:`_CHAIN_ID_BY_NAME`.
+Morpho is deployed on Ethereum mainnet, Arbitrum and Base. This loader
+accepts a chain name and maps it to the API's ``chainId`` parameter.
 
 Output contract
 ---------------
-:meth:`MorphoMarketLoader.read` returns a ``pandas.DataFrame`` with:
-
-* Index: ``time`` — UTC-aware ``DatetimeIndex``, sorted ascending.
-* Columns: ``borrowing_rate`` (float, annualized decimal),
-  ``utilization`` (float, in [0, 1]), ``supply_apy`` (float,
-  annualized decimal).
-
-Empty windows return a same-shape DataFrame with zero rows.
+:meth:`MorphoMarketLoader.read` returns a :class:`LendingHistory` with
+the three columns ``lending_rate``, ``borrowing_rate``, ``utilization``
+indexed by a UTC-aware ``DatetimeIndex``. Empty windows return a
+same-shape :class:`LendingHistory` with zero rows.
 """
 
-from __future__ import annotations
-
+import re
 from datetime import datetime
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -52,13 +43,13 @@ import pandas as pd
 from fractal.loaders._dt import to_seconds, to_utc
 from fractal.loaders._http import HttpClient
 from fractal.loaders.base_loader import Loader, LoaderType
-from fractal.loaders.structs import MorphoMarketHistory
+from fractal.loaders.structs import LendingHistory
 
 
 MORPHO_GRAPHQL_URL: str = "https://blue-api.morpho.org/graphql"
 
 # Chain-name → numeric chainId used by the Morpho GraphQL API.
-_CHAIN_ID_BY_NAME: dict[str, int] = {
+_CHAIN_ID_BY_NAME: Dict[str, int] = {
     "ethereum": 1,
     "arbitrum": 42161,
     "base": 8453,
@@ -67,8 +58,11 @@ _CHAIN_ID_BY_NAME: dict[str, int] = {
 # Default interval. Hourly matches the rest of the backtest's granularity.
 _INTERVAL: str = "HOUR"
 
+# Morpho market ids are 32-byte hex strings ("0x" + 64 hex chars).
+_MARKET_ID_RE = re.compile(r"^0x[a-fA-F0-9]{64}$")
+
 # Output column order is part of the public contract for downstream joins.
-_OUTPUT_COLUMNS: tuple[str, ...] = ("borrowing_rate", "utilization", "supply_apy")
+_OUTPUT_COLUMNS: Tuple[str, ...] = ("lending_rate", "borrowing_rate", "utilization")
 
 _HISTORICAL_QUERY: str = """
 query MarketHistory($id: String!, $cid: Int!, $opts: TimeseriesOptions) {
@@ -93,7 +87,16 @@ def _chain_id(chain: str) -> int:
     return _CHAIN_ID_BY_NAME[key]
 
 
-def _series_to_df(points: list[dict[str, Any]] | None, col: str) -> pd.DataFrame:
+def _validate_market_id(value: str) -> str:
+    """Reject anything that is not a 32-byte hex ``0x``-prefixed string."""
+    if not isinstance(value, str) or not _MARKET_ID_RE.match(value):
+        raise ValueError(
+            f"market_id must match ^0x[a-fA-F0-9]{{64}}$, got {value!r}"
+        )
+    return value.lower()
+
+
+def _series_to_df(points: Optional[List[Dict[str, Any]]], col: str) -> pd.DataFrame:
     """Coerce a ``[{x, y}, …]`` timeseries to a 2-col DataFrame keyed by ``x``."""
     if not points:
         return pd.DataFrame(columns=["x", col])
@@ -106,21 +109,23 @@ def _series_to_df(points: list[dict[str, Any]] | None, col: str) -> pd.DataFrame
 class MorphoMarketLoader(Loader):
     """Hourly historical state for a single Morpho Blue isolated market.
 
-    The loader uses ``Morpho``'s GraphQL endpoint (no API key needed).
-    On cache miss it issues one POST request covering
+    The loader uses Morpho's GraphQL endpoint (no API key needed). On
+    cache miss it issues one POST request covering
     ``[start_time, end_time]`` at hourly resolution; on cache hit it
-    deserializes the on-disk CSV. Cache keys include chain, market id,
-    and both timestamps so different windows do not collide.
+    deserialises the on-disk CSV. Cache keys include chain, market id,
+    and both timestamps as Unix seconds so different windows do not
+    collide.
 
     Args:
-        market_id: 32-byte Morpho market identifier as a ``0x``-hex string.
+        market_id: 32-byte Morpho market identifier as a ``0x``-hex
+            string (``0x`` + 64 hex chars). Validated at construction.
         chain: Lower-case chain name (``"ethereum"``, ``"arbitrum"``,
             ``"base"``); resolved to ``chainId`` internally.
         start_time: Inclusive start of the historical window, UTC.
         end_time: Inclusive end of the historical window, UTC.
-        api_key: Reserved for future authenticated endpoints; the public
-            ``blue-api.morpho.org`` instance does NOT require a key. Pass
-            ``None`` for the public API.
+        api_key: Reserved for future authenticated endpoints; the
+            public ``blue-api.morpho.org`` endpoint does NOT require a
+            key. Pass ``None`` for the public API.
         loader_type: Cache backend; default CSV.
     """
 
@@ -131,15 +136,11 @@ class MorphoMarketLoader(Loader):
         start_time: datetime,
         end_time: datetime,
         *,
-        api_key: str | None = None,
+        api_key: Optional[str] = None,
         loader_type: LoaderType = LoaderType.CSV,
     ) -> None:
         super().__init__(loader_type=loader_type)
-        if not isinstance(market_id, str) or not market_id.startswith("0x"):
-            raise ValueError(
-                f"market_id must be a 0x-prefixed hex string, got {market_id!r}"
-            )
-        self.market_id: str = market_id.lower()
+        self.market_id: str = _validate_market_id(market_id)
         self.chain: str = chain.lower()
         self._chain_id: int = _chain_id(chain)
         self.start_time: datetime = to_utc(start_time)  # type: ignore[assignment]
@@ -150,7 +151,7 @@ class MorphoMarketLoader(Loader):
             raise ValueError(
                 f"end_time {self.end_time} precedes start_time {self.start_time}"
             )
-        self._api_key: str | None = api_key
+        self._api_key: Optional[str] = api_key
         self._http: HttpClient = HttpClient()
 
     # ------------------------------------------------------------------
@@ -167,7 +168,7 @@ class MorphoMarketLoader(Loader):
     # extract / transform
     # ------------------------------------------------------------------
 
-    def _post(self) -> dict[str, Any]:
+    def _post(self) -> Dict[str, Any]:
         """POST the historical query and unwrap GraphQL ``data``."""
         variables = {
             "id": self.market_id,
@@ -178,7 +179,7 @@ class MorphoMarketLoader(Loader):
                 "interval": _INTERVAL,
             },
         }
-        headers: dict[str, str] | None = None
+        headers: Optional[Dict[str, str]] = None
         if self._api_key:
             headers = {
                 "Content-Type": "application/json",
@@ -205,11 +206,11 @@ class MorphoMarketLoader(Loader):
         data = self._post()
         market = data.get("marketByUniqueKey")
         if not market:
-            self._data = pd.DataFrame(columns=list(_OUTPUT_COLUMNS) + ["x"])
+            self._data = pd.DataFrame(columns=["x"] + list(_OUTPUT_COLUMNS))
             return
         hist = market.get("historicalState") or {}
         borrow = _series_to_df(hist.get("borrowApy"), "borrowing_rate")
-        supply = _series_to_df(hist.get("supplyApy"), "supply_apy")
+        supply = _series_to_df(hist.get("supplyApy"), "lending_rate")
         util = _series_to_df(hist.get("utilization"), "utilization")
         merged = borrow.merge(util, on="x", how="outer").merge(
             supply, on="x", how="outer"
@@ -217,21 +218,20 @@ class MorphoMarketLoader(Loader):
         self._data = merged.sort_values("x").reset_index(drop=True)
 
     def transform(self) -> None:
-        """Convert the staging frame to a typed :class:`MorphoMarketHistory`."""
-        cols = list(_OUTPUT_COLUMNS)
+        """Convert the staging frame to a typed :class:`LendingHistory`."""
         if self._data is None or self._data.empty:
-            self._data = MorphoMarketHistory([], [], [], [])
+            self._data = LendingHistory([], [], [], utilization=[])
             return
         df = self._data.copy()
         epoch = df["x"].astype("int64").to_numpy()
-        for c in cols:
+        for c in _OUTPUT_COLUMNS:
             if c not in df.columns:
                 df[c] = np.nan
-        df = df[cols].astype(float)
-        self._data = MorphoMarketHistory(
+        df = df[list(_OUTPUT_COLUMNS)].astype(float)
+        self._data = LendingHistory(
+            lending_rates=df["lending_rate"].to_numpy(),
             borrowing_rates=df["borrowing_rate"].to_numpy(),
             utilization=df["utilization"].to_numpy(),
-            supply_apys=df["supply_apy"].to_numpy(),
             time=epoch,
         )
 
@@ -239,10 +239,39 @@ class MorphoMarketLoader(Loader):
     # read
     # ------------------------------------------------------------------
 
-    def read(self, with_run: bool = False) -> MorphoMarketHistory:
-        """Return the hourly ``MorphoMarketHistory``; run pipeline on cache miss."""
+    def read(self, with_run: bool = False) -> LendingHistory:
+        """Return the hourly ``LendingHistory``; run pipeline on cache miss."""
         if with_run:
             self.run()
         else:
             self._read(self._cache_key())
+            self._data = _rebuild_from_cache(self._data)
         return self._data
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _rebuild_from_cache(data: Any) -> LendingHistory:
+    """Coerce a cached ``pd.DataFrame`` (or ``LendingHistory``) back to typed form."""
+    if isinstance(data, LendingHistory):
+        return data
+    if data is None or (isinstance(data, pd.DataFrame) and data.empty):
+        return LendingHistory([], [], [], utilization=[])
+    df = data.copy() if isinstance(data, pd.DataFrame) else pd.DataFrame(data)
+    if "time" in df.columns:
+        df["time"] = pd.to_datetime(df["time"], utc=True)
+        df = df.set_index("time").sort_index()
+    idx = pd.to_datetime(df.index, utc=True)
+    if not isinstance(idx, pd.DatetimeIndex):
+        idx = pd.DatetimeIndex(idx)
+    idx.name = "time"
+    for col in _OUTPUT_COLUMNS:
+        if col not in df.columns:
+            df[col] = float("nan")
+    return LendingHistory(
+        lending_rates=df["lending_rate"].to_numpy(),
+        borrowing_rates=df["borrowing_rate"].to_numpy(),
+        utilization=df["utilization"].to_numpy(),
+        time=idx,
+    )

--- a/fractal/loaders/morpho.py
+++ b/fractal/loaders/morpho.py
@@ -1,0 +1,248 @@
+"""Morpho Blue market loader — hourly borrow rate and utilization.
+
+Endpoint
+--------
+Morpho exposes market data through a keyless GraphQL endpoint at
+``https://blue-api.morpho.org/graphql``. The relevant root field is
+``marketByUniqueKey(uniqueKey, chainId)``; it returns a ``Market`` whose
+``historicalState`` selection produces timeseries with the requested
+``interval`` (``HOUR`` / ``DAY`` / …) and ``[startTimestamp, endTimestamp]``
+window. Each timeseries entry is a ``FloatDataPoint`` of shape
+``{x: <unix_seconds>, y: <decimal>}``.
+
+The fields we read are already **annualized decimals**:
+
+* ``borrowApy`` — annualized borrow APY paid by debtors. Equivalent to
+  the ``borrowing_rate`` consumed by :class:`MorphoEntity`. Morpho APIs
+  expose this as ``borrowApy`` (compounded view) rather than the raw
+  per-second rate; for backtest granularity the difference between
+  continuous and compounded conventions is < 1 bp at typical rates.
+* ``supplyApy`` — annualized supply APY earned by lenders (informational
+  here — the strategy entity pins ``lending_rate=0`` because Pendle PT
+  collateral does not accrue supplier yield in Morpho).
+* ``utilization`` — fraction of supplied debt asset currently borrowed,
+  in [0, 1]. Drives the IRM and is useful for rate-spike monitoring.
+
+Chains
+------
+Morpho is deployed on Ethereum mainnet and Arbitrum (plus Base, etc.).
+This loader accepts a chain name and maps it to the API's ``chainId``
+parameter. Add new chains by extending :data:`_CHAIN_ID_BY_NAME`.
+
+Output contract
+---------------
+:meth:`MorphoMarketLoader.read` returns a ``pandas.DataFrame`` with:
+
+* Index: ``time`` — UTC-aware ``DatetimeIndex``, sorted ascending.
+* Columns: ``borrowing_rate`` (float, annualized decimal),
+  ``utilization`` (float, in [0, 1]), ``supply_apy`` (float,
+  annualized decimal).
+
+Empty windows return a same-shape DataFrame with zero rows.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from fractal.loaders._dt import to_seconds, to_utc
+from fractal.loaders._http import HttpClient
+from fractal.loaders.base_loader import Loader, LoaderType
+from fractal.loaders.structs import MorphoMarketHistory
+
+
+MORPHO_GRAPHQL_URL: str = "https://blue-api.morpho.org/graphql"
+
+# Chain-name → numeric chainId used by the Morpho GraphQL API.
+_CHAIN_ID_BY_NAME: dict[str, int] = {
+    "ethereum": 1,
+    "arbitrum": 42161,
+    "base": 8453,
+}
+
+# Default interval. Hourly matches the rest of the backtest's granularity.
+_INTERVAL: str = "HOUR"
+
+# Output column order is part of the public contract for downstream joins.
+_OUTPUT_COLUMNS: tuple[str, ...] = ("borrowing_rate", "utilization", "supply_apy")
+
+_HISTORICAL_QUERY: str = """
+query MarketHistory($id: String!, $cid: Int!, $opts: TimeseriesOptions) {
+  marketByUniqueKey(uniqueKey: $id, chainId: $cid) {
+    historicalState {
+      borrowApy(options: $opts) { x y }
+      supplyApy(options: $opts) { x y }
+      utilization(options: $opts) { x y }
+    }
+  }
+}
+"""
+
+
+def _chain_id(chain: str) -> int:
+    """Map a chain name to the Morpho API's integer chainId."""
+    key = chain.lower()
+    if key not in _CHAIN_ID_BY_NAME:
+        raise ValueError(
+            f"unsupported chain {chain!r}; expected one of {sorted(_CHAIN_ID_BY_NAME)}"
+        )
+    return _CHAIN_ID_BY_NAME[key]
+
+
+def _series_to_df(points: list[dict[str, Any]] | None, col: str) -> pd.DataFrame:
+    """Coerce a ``[{x, y}, …]`` timeseries to a 2-col DataFrame keyed by ``x``."""
+    if not points:
+        return pd.DataFrame(columns=["x", col])
+    df = pd.DataFrame(points)
+    df["x"] = df["x"].astype("int64")
+    df[col] = df["y"].astype(float)
+    return df[["x", col]]
+
+
+class MorphoMarketLoader(Loader):
+    """Hourly historical state for a single Morpho Blue isolated market.
+
+    The loader uses ``Morpho``'s GraphQL endpoint (no API key needed).
+    On cache miss it issues one POST request covering
+    ``[start_time, end_time]`` at hourly resolution; on cache hit it
+    deserializes the on-disk CSV. Cache keys include chain, market id,
+    and both timestamps so different windows do not collide.
+
+    Args:
+        market_id: 32-byte Morpho market identifier as a ``0x``-hex string.
+        chain: Lower-case chain name (``"ethereum"``, ``"arbitrum"``,
+            ``"base"``); resolved to ``chainId`` internally.
+        start_time: Inclusive start of the historical window, UTC.
+        end_time: Inclusive end of the historical window, UTC.
+        api_key: Reserved for future authenticated endpoints; the public
+            ``blue-api.morpho.org`` instance does NOT require a key. Pass
+            ``None`` for the public API.
+        loader_type: Cache backend; default CSV.
+    """
+
+    def __init__(
+        self,
+        market_id: str,
+        chain: str,
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        api_key: str | None = None,
+        loader_type: LoaderType = LoaderType.CSV,
+    ) -> None:
+        super().__init__(loader_type=loader_type)
+        if not isinstance(market_id, str) or not market_id.startswith("0x"):
+            raise ValueError(
+                f"market_id must be a 0x-prefixed hex string, got {market_id!r}"
+            )
+        self.market_id: str = market_id.lower()
+        self.chain: str = chain.lower()
+        self._chain_id: int = _chain_id(chain)
+        self.start_time: datetime = to_utc(start_time)  # type: ignore[assignment]
+        self.end_time: datetime = to_utc(end_time)  # type: ignore[assignment]
+        if self.start_time is None or self.end_time is None:
+            raise ValueError("start_time and end_time are required")
+        if self.end_time < self.start_time:
+            raise ValueError(
+                f"end_time {self.end_time} precedes start_time {self.start_time}"
+            )
+        self._api_key: str | None = api_key
+        self._http: HttpClient = HttpClient()
+
+    # ------------------------------------------------------------------
+    # Cache identity
+    # ------------------------------------------------------------------
+
+    def _cache_key(self) -> str:
+        return (
+            f"{self.chain}-{self.market_id}-"
+            f"{to_seconds(self.start_time)}-{to_seconds(self.end_time)}"
+        )
+
+    # ------------------------------------------------------------------
+    # extract / transform
+    # ------------------------------------------------------------------
+
+    def _post(self) -> dict[str, Any]:
+        """POST the historical query and unwrap GraphQL ``data``."""
+        variables = {
+            "id": self.market_id,
+            "cid": self._chain_id,
+            "opts": {
+                "startTimestamp": to_seconds(self.start_time),
+                "endTimestamp": to_seconds(self.end_time),
+                "interval": _INTERVAL,
+            },
+        }
+        headers: dict[str, str] | None = None
+        if self._api_key:
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self._api_key}",
+            }
+        payload = self._http.post(
+            MORPHO_GRAPHQL_URL,
+            json={"query": _HISTORICAL_QUERY, "variables": variables},
+            headers=headers,
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                f"Morpho GraphQL: expected JSON object, got {type(payload).__name__}"
+            )
+        if "errors" in payload:
+            raise RuntimeError(f"Morpho GraphQL errors: {payload['errors']}")
+        data = payload.get("data") or {}
+        if not isinstance(data, dict):
+            raise RuntimeError("Morpho GraphQL: missing 'data' object")
+        return data
+
+    def extract(self) -> None:
+        """Fetch the timeseries triple and stash an unmerged staging frame."""
+        data = self._post()
+        market = data.get("marketByUniqueKey")
+        if not market:
+            self._data = pd.DataFrame(columns=list(_OUTPUT_COLUMNS) + ["x"])
+            return
+        hist = market.get("historicalState") or {}
+        borrow = _series_to_df(hist.get("borrowApy"), "borrowing_rate")
+        supply = _series_to_df(hist.get("supplyApy"), "supply_apy")
+        util = _series_to_df(hist.get("utilization"), "utilization")
+        merged = borrow.merge(util, on="x", how="outer").merge(
+            supply, on="x", how="outer"
+        )
+        self._data = merged.sort_values("x").reset_index(drop=True)
+
+    def transform(self) -> None:
+        """Convert the staging frame to a typed :class:`MorphoMarketHistory`."""
+        cols = list(_OUTPUT_COLUMNS)
+        if self._data is None or self._data.empty:
+            self._data = MorphoMarketHistory([], [], [], [])
+            return
+        df = self._data.copy()
+        epoch = df["x"].astype("int64").to_numpy()
+        for c in cols:
+            if c not in df.columns:
+                df[c] = np.nan
+        df = df[cols].astype(float)
+        self._data = MorphoMarketHistory(
+            borrowing_rates=df["borrowing_rate"].to_numpy(),
+            utilization=df["utilization"].to_numpy(),
+            supply_apys=df["supply_apy"].to_numpy(),
+            time=epoch,
+        )
+
+    # ------------------------------------------------------------------
+    # read
+    # ------------------------------------------------------------------
+
+    def read(self, with_run: bool = False) -> MorphoMarketHistory:
+        """Return the hourly ``MorphoMarketHistory``; run pipeline on cache miss."""
+        if with_run:
+            self.run()
+        else:
+            self._read(self._cache_key())
+        return self._data

--- a/fractal/loaders/pendle.py
+++ b/fractal/loaders/pendle.py
@@ -1,0 +1,151 @@
+"""Pendle public-REST loader.
+
+Endpoint:
+    GET https://api-v2.pendle.finance/core/v1/{chain_id}/markets/{market}/historical-data
+        ?time_frame=hour&from=<ISO>&to=<ISO>
+
+Returns parallel arrays (timestamp, impliedApy, tvl). PT mid-price is
+not exposed by the API, so we compute it from the implied yield and
+the time-to-expiry using the linear convention that Pendle's own
+oracle uses (``pt_price = 1 - implied_yield * tau``, clamped to
+``[0, 1]``). The linear approximation matches what Morpho's PT oracle
+reads on-chain — keeps pricing consistent across the stack.
+
+The endpoint caps returned rows (~60-day window at hourly granularity).
+For longer histories the loader would have to paginate via successive
+``from`` slices; we leave that as a follow-up when a concrete
+multi-cycle use case arrives upstream.
+"""
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from fractal.loaders._dt import to_utc
+from fractal.loaders.base_loader import Loader, LoaderType
+from fractal.loaders.structs import PendleMarketHistory
+
+PENDLE_REST_BASE = "https://api-v2.pendle.finance/core/v1"
+_SECONDS_PER_YEAR = 365.25 * 24.0 * 3600.0
+_REQUEST_TIMEOUT_S = 30.0
+
+
+def _compute_pt_price_linear(implied_yield: float, seconds_to_expiry: float) -> float:
+    """``pt_price = 1 - implied_yield * tau``, clamped to ``[0, 1]``."""
+    if seconds_to_expiry <= 0:
+        return 1.0
+    tau = seconds_to_expiry / _SECONDS_PER_YEAR
+    price = 1.0 - implied_yield * tau
+    if price < 0.0:
+        return 0.0
+    if price > 1.0:
+        return 1.0
+    return price
+
+
+class PendleMarketLoader(Loader):
+    """Hourly Pendle PT market history for a single (chain, market) pair.
+
+    Pipeline: ``extract`` GETs the historical-data endpoint and stashes
+    the JSON in ``self._raw``; ``transform`` parses the parallel-array
+    payload into a :class:`PendleMarketHistory`; ``read(with_run=True)``
+    runs the pipeline and writes a CSV cache.
+    """
+
+    def __init__(
+        self,
+        market_address: str,
+        expiry_timestamp: int,
+        start_time: datetime,
+        end_time: datetime,
+        chain_id: int = 1,
+        loader_type: LoaderType = LoaderType.CSV,
+        api_key: Optional[str] = None,
+    ) -> None:
+        super().__init__(loader_type=loader_type)
+        self.market_address: str = market_address.lower()
+        self.expiry_timestamp: int = int(expiry_timestamp)
+        self.start_time: datetime = to_utc(start_time)
+        self.end_time: datetime = to_utc(end_time)
+        self.chain_id: int = int(chain_id)
+        self._api_key: Optional[str] = api_key
+        self._raw: Dict[str, Any] = {}
+
+    def _cache_key(self) -> str:
+        s = self.start_time.strftime("%Y%m%d")
+        e = self.end_time.strftime("%Y%m%d")
+        return f"{self.chain_id}-{self.market_address}-{s}-{e}"
+
+    def _url(self) -> str:
+        return (
+            f"{PENDLE_REST_BASE}/{self.chain_id}/markets/"
+            f"{self.market_address}/historical-data"
+        )
+
+    def _params(self) -> Dict[str, str]:
+        return {
+            "time_frame": "hour",
+            "from": self.start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "to": self.end_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def extract(self) -> None:
+        response = requests.get(
+            self._url(),
+            params=self._params(),
+            headers=self._headers(),
+            timeout=_REQUEST_TIMEOUT_S,
+        )
+        response.raise_for_status()
+        payload = response.json() if callable(getattr(response, "json", None)) else {}
+        self._raw = payload if isinstance(payload, dict) else {}
+
+    def transform(self) -> None:
+        payload = self._raw
+        timestamps = payload.get("timestamp") or []
+        implied = payload.get("impliedApy") or []
+        tvl = payload.get("tvl") or []
+        if not timestamps:
+            self._data = PendleMarketHistory([], [], [], [], [])
+            return
+
+        n = min(len(timestamps), len(implied), len(tvl))
+        out_ts: List[int] = []
+        out_pt: List[float] = []
+        out_iy: List[float] = []
+        out_se: List[float] = []
+        out_pl: List[float] = []
+        for i in range(n):
+            try:
+                epoch = int(timestamps[i])
+                implied_y = float(implied[i])
+                liquidity = float(tvl[i])
+            except (TypeError, ValueError):
+                continue
+            seconds_to_expiry = float(max(self.expiry_timestamp - epoch, 0))
+            pt = _compute_pt_price_linear(implied_y, seconds_to_expiry)
+            out_ts.append(epoch)
+            out_pt.append(pt)
+            out_iy.append(implied_y)
+            out_se.append(seconds_to_expiry)
+            out_pl.append(liquidity)
+        self._data = PendleMarketHistory(
+            pt_prices=out_pt,
+            implied_yields=out_iy,
+            seconds_to_expiry=out_se,
+            pool_liquidity=out_pl,
+            time=out_ts,
+        )
+
+    def read(self, with_run: bool = False) -> PendleMarketHistory:
+        if with_run:
+            self.run()
+        else:
+            self._read(self._cache_key())
+        return self._data

--- a/fractal/loaders/pendle.py
+++ b/fractal/loaders/pendle.py
@@ -4,7 +4,8 @@ Endpoint:
     GET https://api-v2.pendle.finance/core/v1/{chain_id}/markets/{market}/historical-data
         ?time_frame=hour&from=<ISO>&to=<ISO>
 
-Returns parallel arrays (timestamp, impliedApy, tvl). PT mid-price is
+Returns parallel arrays (``timestamp``, ``impliedApy``, ``tvl``, plus
+optional ``baseApy``, ``underlyingApy``, ``maxApy``). PT mid-price is
 not exposed by the API, so we compute it from the implied yield and
 the time-to-expiry using the linear convention that Pendle's own
 oracle uses (``pt_price = 1 - implied_yield * tau``, clamped to
@@ -17,17 +18,30 @@ For longer histories the loader would have to paginate via successive
 multi-cycle use case arrives upstream.
 """
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
-import requests
+import pandas as pd
 
-from fractal.loaders._dt import to_utc
+from fractal.loaders._dt import to_seconds, to_utc
+from fractal.loaders._http import HttpClient
 from fractal.loaders.base_loader import Loader, LoaderType
 from fractal.loaders.structs import PendleMarketHistory
+from fractal.loaders.thegraph.base_graph_loader import validate_evm_address
 
 PENDLE_REST_BASE = "https://api-v2.pendle.finance/core/v1"
 _SECONDS_PER_YEAR = 365.25 * 24.0 * 3600.0
-_REQUEST_TIMEOUT_S = 30.0
+
+_SUPPORTED_CHAIN_IDS: Set[int] = {1, 42161, 8453}
+
+_OUTPUT_COLUMNS = (
+    "pt_price",
+    "implied_yield",
+    "seconds_to_expiry",
+    "pool_liquidity",
+    "base_apy",
+    "underlying_apy",
+    "max_apy",
+)
 
 
 def _compute_pt_price_linear(implied_yield: float, seconds_to_expiry: float) -> float:
@@ -49,7 +63,9 @@ class PendleMarketLoader(Loader):
     Pipeline: ``extract`` GETs the historical-data endpoint and stashes
     the JSON in ``self._raw``; ``transform`` parses the parallel-array
     payload into a :class:`PendleMarketHistory`; ``read(with_run=True)``
-    runs the pipeline and writes a CSV cache.
+    runs the pipeline and writes a CSV cache; ``read(with_run=False)``
+    rehydrates the cached CSV back into a :class:`PendleMarketHistory`
+    so both paths return the same typed contract.
     """
 
     def __init__(
@@ -63,18 +79,34 @@ class PendleMarketLoader(Loader):
         api_key: Optional[str] = None,
     ) -> None:
         super().__init__(loader_type=loader_type)
-        self.market_address: str = market_address.lower()
+        self.market_address: str = validate_evm_address(
+            market_address, field="market_address"
+        )
         self.expiry_timestamp: int = int(expiry_timestamp)
         self.start_time: datetime = to_utc(start_time)
         self.end_time: datetime = to_utc(end_time)
-        self.chain_id: int = int(chain_id)
+        if self.end_time < self.start_time:
+            raise ValueError(
+                f"end_time {self.end_time} precedes start_time {self.start_time}"
+            )
+        chain_id_int = int(chain_id)
+        if chain_id_int not in _SUPPORTED_CHAIN_IDS:
+            raise ValueError(
+                f"chain_id {chain_id_int} not supported; "
+                f"expected one of {sorted(_SUPPORTED_CHAIN_IDS)}"
+            )
+        self.chain_id: int = chain_id_int
         self._api_key: Optional[str] = api_key
         self._raw: Dict[str, Any] = {}
+        self._http: HttpClient = HttpClient()
 
     def _cache_key(self) -> str:
-        s = self.start_time.strftime("%Y%m%d")
-        e = self.end_time.strftime("%Y%m%d")
-        return f"{self.chain_id}-{self.market_address}-{s}-{e}"
+        # Use full epoch seconds (not just dates) so two windows that share
+        # a date but differ by hours don't collide on disk.
+        return (
+            f"{self.chain_id}-{self.market_address}-"
+            f"{to_seconds(self.start_time)}-{to_seconds(self.end_time)}"
+        )
 
     def _url(self) -> str:
         return (
@@ -89,21 +121,8 @@ class PendleMarketLoader(Loader):
             "to": self.end_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
 
-    def _headers(self) -> Dict[str, str]:
-        headers = {"Accept": "application/json"}
-        if self._api_key:
-            headers["Authorization"] = f"Bearer {self._api_key}"
-        return headers
-
     def extract(self) -> None:
-        response = requests.get(
-            self._url(),
-            params=self._params(),
-            headers=self._headers(),
-            timeout=_REQUEST_TIMEOUT_S,
-        )
-        response.raise_for_status()
-        payload = response.json() if callable(getattr(response, "json", None)) else {}
+        payload = self._http.get(self._url(), params=self._params())
         self._raw = payload if isinstance(payload, dict) else {}
 
     def transform(self) -> None:
@@ -111,8 +130,11 @@ class PendleMarketLoader(Loader):
         timestamps = payload.get("timestamp") or []
         implied = payload.get("impliedApy") or []
         tvl = payload.get("tvl") or []
+        base = payload.get("baseApy") or []
+        underlying = payload.get("underlyingApy") or []
+        maxapy = payload.get("maxApy") or []
         if not timestamps:
-            self._data = PendleMarketHistory([], [], [], [], [])
+            self._data = _empty_history()
             return
 
         n = min(len(timestamps), len(implied), len(tvl))
@@ -121,6 +143,9 @@ class PendleMarketLoader(Loader):
         out_iy: List[float] = []
         out_se: List[float] = []
         out_pl: List[float] = []
+        out_b: List[float] = []
+        out_u: List[float] = []
+        out_m: List[float] = []
         for i in range(n):
             try:
                 epoch = int(timestamps[i])
@@ -135,17 +160,88 @@ class PendleMarketLoader(Loader):
             out_iy.append(implied_y)
             out_se.append(seconds_to_expiry)
             out_pl.append(liquidity)
+            out_b.append(_safe_float(base, i))
+            out_u.append(_safe_float(underlying, i))
+            out_m.append(_safe_float(maxapy, i))
+
         self._data = PendleMarketHistory(
             pt_prices=out_pt,
             implied_yields=out_iy,
             seconds_to_expiry=out_se,
             pool_liquidity=out_pl,
             time=out_ts,
+            base_apy=out_b,
+            underlying_apy=out_u,
+            max_apy=out_m,
         )
 
     def read(self, with_run: bool = False) -> PendleMarketHistory:
+        """Return the hourly ``PendleMarketHistory``.
+
+        Cache-hit path rehydrates the CSV into the typed history so both
+        ``with_run=True`` and ``with_run=False`` paths return the same
+        type and the same UTC ``DatetimeIndex``.
+        """
         if with_run:
             self.run()
         else:
             self._read(self._cache_key())
+            self._data = _rebuild_from_cache(self._data)
         return self._data
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _safe_float(seq: Any, idx: int) -> float:
+    """``float(seq[idx])`` or ``NaN`` if missing / not coercible."""
+    try:
+        return float(seq[idx])
+    except (TypeError, ValueError, IndexError, KeyError):
+        return float("nan")
+
+
+def _empty_history() -> PendleMarketHistory:
+    return PendleMarketHistory(
+        pt_prices=[],
+        implied_yields=[],
+        seconds_to_expiry=[],
+        pool_liquidity=[],
+        time=[],
+        base_apy=[],
+        underlying_apy=[],
+        max_apy=[],
+    )
+
+
+def _rebuild_from_cache(data: Any) -> PendleMarketHistory:
+    """Coerce a cached ``pd.DataFrame`` (or ``PendleMarketHistory``) back to typed form.
+
+    The CSV cache loses the typed-class identity and the index name; we
+    restore both here so cache reads behave identically to fresh runs.
+    """
+    if isinstance(data, PendleMarketHistory):
+        return data
+    if data is None or (isinstance(data, pd.DataFrame) and data.empty):
+        return _empty_history()
+    df = data.copy() if isinstance(data, pd.DataFrame) else pd.DataFrame(data)
+    if "time" in df.columns:
+        df["time"] = pd.to_datetime(df["time"], utc=True)
+        df = df.set_index("time").sort_index()
+    idx = pd.to_datetime(df.index, utc=True)
+    if not isinstance(idx, pd.DatetimeIndex):
+        idx = pd.DatetimeIndex(idx)
+    idx.name = "time"
+    for col in _OUTPUT_COLUMNS:
+        if col not in df.columns:
+            df[col] = float("nan")
+    return PendleMarketHistory(
+        pt_prices=df["pt_price"].to_numpy(),
+        implied_yields=df["implied_yield"].to_numpy(),
+        seconds_to_expiry=df["seconds_to_expiry"].to_numpy(),
+        pool_liquidity=df["pool_liquidity"].to_numpy(),
+        time=idx,
+        base_apy=df["base_apy"].to_numpy(),
+        underlying_apy=df["underlying_apy"].to_numpy(),
+        max_apy=df["max_apy"].to_numpy(),
+    )

--- a/fractal/loaders/pendle_ohlcv.py
+++ b/fractal/loaders/pendle_ohlcv.py
@@ -1,0 +1,215 @@
+"""Pendle public-REST OHLCV loader (PT / YT / SY token prices).
+
+Endpoint:
+    GET https://api-v2.pendle.finance/core/v4/{chain_id}/prices/{address}/ohlcv
+        ?time_frame=<1m|5m|15m|1h|4h|1d|1w>&from=<unix_seconds>&to=<unix_seconds>
+
+The endpoint returns OHLCV bars for any Pendle-tracked asset address —
+PT, YT, SY or the underlying — denominated in USD. Bars are produced
+from Pendle's own oracle so they are consistent with the AMM prices
+exposed by the historical-data endpoint that backs
+:class:`PendleMarketLoader`.
+
+Use this loader when you want a candlestick view of the PT / YT mark
+through time (drawdown analysis, vol estimation, plotting). For
+implied-yield / liquidity timeseries keyed off the *market* contract
+rather than the *token* address, use :class:`PendleMarketLoader`.
+"""
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set
+
+from fractal.loaders._dt import to_seconds, to_utc
+from fractal.loaders._http import HttpClient
+from fractal.loaders.base_loader import Loader, LoaderType
+from fractal.loaders.structs import KlinesHistory
+from fractal.loaders.thegraph.base_graph_loader import validate_evm_address
+
+PENDLE_REST_BASE: str = "https://api-v2.pendle.finance/core"
+
+_SUPPORTED_CHAIN_IDS: Set[int] = {1, 42161, 8453}
+
+_ALLOWED_TIME_FRAMES: Set[str] = {"1m", "5m", "15m", "1h", "4h", "1d", "1w"}
+
+
+class PendleOHLCVLoader(Loader):
+    """OHLCV bars for a Pendle-tracked token (PT / YT / SY / underlying).
+
+    Pipeline: ``extract`` GETs the OHLCV endpoint via the shared
+    :class:`HttpClient`; ``transform`` parses the bar list into a typed
+    :class:`KlinesHistory`; ``read`` returns the same type on both
+    cache-hit and cache-miss paths.
+
+    Args:
+        token_address: 20-byte EVM address of the PT / YT / SY token.
+        chain_id: ``1`` (Ethereum), ``42161`` (Arbitrum), or ``8453``
+            (Base).
+        start_time: Inclusive start of the historical window, UTC.
+        end_time: Inclusive end of the historical window, UTC.
+        time_frame: Bar resolution; one of ``{1m, 5m, 15m, 1h, 4h, 1d, 1w}``.
+        api_key: Reserved for future authenticated endpoints; the
+            public Pendle REST endpoints do NOT require a key.
+        loader_type: Cache backend; default CSV.
+    """
+
+    def __init__(
+        self,
+        token_address: str,
+        start_time: datetime,
+        end_time: datetime,
+        chain_id: int = 1,
+        *,
+        time_frame: str = "1h",
+        api_key: Optional[str] = None,
+        loader_type: LoaderType = LoaderType.CSV,
+    ) -> None:
+        super().__init__(loader_type=loader_type)
+        self.token_address: str = validate_evm_address(
+            token_address, field="token_address"
+        )
+        chain_id_int = int(chain_id)
+        if chain_id_int not in _SUPPORTED_CHAIN_IDS:
+            raise ValueError(
+                f"chain_id {chain_id_int} not supported; "
+                f"expected one of {sorted(_SUPPORTED_CHAIN_IDS)}"
+            )
+        if time_frame not in _ALLOWED_TIME_FRAMES:
+            raise ValueError(
+                f"time_frame must be one of {sorted(_ALLOWED_TIME_FRAMES)}, "
+                f"got {time_frame!r}"
+            )
+        self.chain_id: int = chain_id_int
+        self.start_time: datetime = to_utc(start_time)
+        self.end_time: datetime = to_utc(end_time)
+        if self.end_time < self.start_time:
+            raise ValueError(
+                f"end_time {self.end_time} precedes start_time {self.start_time}"
+            )
+        self.time_frame: str = time_frame
+        self._api_key: Optional[str] = api_key
+        self._raw: Any = None
+        self._http: HttpClient = HttpClient()
+
+    def _cache_key(self) -> str:
+        return (
+            f"{self.chain_id}-{self.token_address}-{self.time_frame}-"
+            f"{to_seconds(self.start_time)}-{to_seconds(self.end_time)}"
+        )
+
+    def _url(self) -> str:
+        return (
+            f"{PENDLE_REST_BASE}/v4/{self.chain_id}/prices/"
+            f"{self.token_address}/ohlcv"
+        )
+
+    def _params(self) -> Dict[str, Any]:
+        return {
+            "time_frame": self.time_frame,
+            "from": to_seconds(self.start_time),
+            "to": to_seconds(self.end_time),
+        }
+
+    def extract(self) -> None:
+        payload = self._http.get(self._url(), params=self._params())
+        self._raw = payload
+
+    def transform(self) -> None:
+        bars = _extract_bars(self._raw)
+        if not bars:
+            self._data = _empty_klines()
+            return
+        time: List[int] = []
+        opens: List[float] = []
+        highs: List[float] = []
+        lows: List[float] = []
+        closes: List[float] = []
+        volumes: List[float] = []
+        for bar in bars:
+            try:
+                t = int(bar.get("time") or bar.get("t") or bar.get("timestamp"))
+                o = float(bar.get("open", bar.get("o", 0.0)))
+                h = float(bar.get("high", bar.get("h", 0.0)))
+                low = float(bar.get("low", bar.get("l", 0.0)))
+                c = float(bar.get("close", bar.get("c", 0.0)))
+                v = float(bar.get("volume", bar.get("v", 0.0)))
+            except (TypeError, ValueError, KeyError):
+                continue
+            time.append(t)
+            opens.append(o)
+            highs.append(h)
+            lows.append(low)
+            closes.append(c)
+            volumes.append(v)
+        self._data = KlinesHistory(
+            time=time,
+            open=opens,
+            high=highs,
+            low=lows,
+            close=closes,
+            volume=volumes,
+        )
+
+    def read(self, with_run: bool = False) -> KlinesHistory:
+        """Return the OHLCV ``KlinesHistory`` on both cache paths."""
+        if with_run:
+            self.run()
+        else:
+            self._read(self._cache_key())
+            self._data = _rebuild_from_cache(self._data)
+        return self._data
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _extract_bars(raw: Any) -> List[Dict[str, Any]]:
+    """Locate the bar list within a Pendle OHLCV response payload.
+
+    Pendle's OHLCV endpoint has evolved across minor versions; this
+    helper tolerates the two shapes observed in production (top-level
+    ``list`` and ``{"results": [...]}`` / ``{"data": [...]}`` wrappers).
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [r for r in raw if isinstance(r, dict)]
+    if isinstance(raw, dict):
+        for key in ("results", "data", "ohlcv", "bars"):
+            v = raw.get(key)
+            if isinstance(v, list):
+                return [r for r in v if isinstance(r, dict)]
+    return []
+
+
+def _empty_klines() -> KlinesHistory:
+    return KlinesHistory(
+        time=[], open=[], high=[], low=[], close=[], volume=[]
+    )
+
+
+def _rebuild_from_cache(data: Any) -> KlinesHistory:
+    """Coerce a cached DataFrame (or ``KlinesHistory``) back to typed form."""
+    import pandas as pd
+
+    if isinstance(data, KlinesHistory):
+        return data
+    if data is None or (isinstance(data, pd.DataFrame) and data.empty):
+        return _empty_klines()
+    df = data.copy() if isinstance(data, pd.DataFrame) else pd.DataFrame(data)
+    if "time" in df.columns:
+        df["time"] = pd.to_datetime(df["time"], utc=True)
+        df = df.set_index("time").sort_index()
+    idx = pd.to_datetime(df.index, utc=True)
+    if not isinstance(idx, pd.DatetimeIndex):
+        idx = pd.DatetimeIndex(idx)
+    idx.name = "time"
+    for col in ("open", "high", "low", "close", "volume"):
+        if col not in df.columns:
+            df[col] = 0.0
+    return KlinesHistory(
+        time=idx,
+        open=df["open"].to_numpy(),
+        high=df["high"].to_numpy(),
+        low=df["low"].to_numpy(),
+        close=df["close"].to_numpy(),
+        volume=df["volume"].to_numpy(),
+    )

--- a/fractal/loaders/structs.py
+++ b/fractal/loaders/structs.py
@@ -7,16 +7,34 @@ loaders return an instance of the correct shape with zero rows.
 
 Simulation loaders that produce multiple synthetic trajectories return a
 :data:`TrajectoryBundle` — a list of one of the structures above.
+
+Loaders SHOULD pass either ``pandas``/``numpy`` datetime arrays or a
+``Sequence[int]`` of **Unix epoch seconds** to the constructors below.
+The shared helper :func:`_to_utc_index` detects the integer-seconds
+case automatically; passing nanoseconds is a bug.
 """
-from typing import List, Optional
+from typing import List, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
 
+ArrayLike = Union[np.ndarray, Sequence[float], pd.Series]
+TimeLike = Union[np.ndarray, Sequence[int], Sequence[pd.Timestamp], pd.DatetimeIndex]
 
-def _to_utc_index(time: np.ndarray) -> pd.DatetimeIndex:
-    """Coerce an array-like of timestamps to a UTC-aware ``DatetimeIndex``."""
-    idx = pd.to_datetime(time, utc=True)
+
+def _to_utc_index(time: TimeLike) -> pd.DatetimeIndex:
+    """Coerce an array-like of timestamps to a UTC-aware ``DatetimeIndex``.
+
+    Integer arrays are interpreted as **Unix epoch seconds** (a common
+    REST-API convention), not as nanoseconds — pandas's default
+    integer-to-datetime path would otherwise place values around 1970.
+    Pass ``pd.Timestamp``/``datetime`` objects to bypass the heuristic.
+    """
+    arr = np.asarray(time)
+    if arr.size > 0 and np.issubdtype(arr.dtype, np.integer):
+        idx = pd.to_datetime(arr, unit="s", utc=True)
+    else:
+        idx = pd.to_datetime(arr, utc=True)
     if not isinstance(idx, pd.DatetimeIndex):
         idx = pd.DatetimeIndex(idx)
     idx.name = "time"
@@ -48,21 +66,35 @@ class RateHistory(pd.DataFrame):
 
 
 class LendingHistory(pd.DataFrame):
-    """Lending+borrowing rate series. Columns: ``lending_rate``, ``borrowing_rate``."""
+    """Lending+borrowing rate series.
+
+    Columns:
+        ``lending_rate`` — annualised supply APY (decimal,
+            ``0.04`` = 4% APY).
+        ``borrowing_rate`` — annualised borrow APY (decimal).
+        ``utilization`` — fraction of supplied debt currently borrowed,
+            in ``[0, 1]``. Optional: present only when the source feed
+            exposes utilization (e.g. Morpho Blue). Populated as
+            ``NaN`` otherwise.
+    """
 
     def __init__(
         self,
-        lending_rates: np.ndarray,
-        borrowing_rates: np.ndarray,
-        time: np.ndarray,
+        lending_rates: ArrayLike,
+        borrowing_rates: ArrayLike,
+        time: TimeLike,
+        utilization: Optional[ArrayLike] = None,
     ):
-        super().__init__(
-            data={
-                "lending_rate": np.asarray(lending_rates, dtype=float),
-                "borrowing_rate": np.asarray(borrowing_rates, dtype=float),
-            },
-            index=_to_utc_index(time),
-        )
+        data = {
+            "lending_rate": np.asarray(lending_rates, dtype=float),
+            "borrowing_rate": np.asarray(borrowing_rates, dtype=float),
+        }
+        n = len(data["lending_rate"])
+        if utilization is None:
+            data["utilization"] = np.full(n, np.nan, dtype=float)
+        else:
+            data["utilization"] = np.asarray(utilization, dtype=float)
+        super().__init__(data=data, index=_to_utc_index(time))
 
 
 class PoolHistory(pd.DataFrame):
@@ -109,49 +141,41 @@ class PendleMarketHistory(pd.DataFrame):
         ``seconds_to_expiry`` — seconds remaining until PT redeem
             unlocks.
         ``pool_liquidity`` — total Pendle pool liquidity in numeraire.
+        ``base_apy`` — Pendle's reported base APY (decimal); optional
+            informational column, ``NaN`` when not exposed by the feed.
+        ``underlying_apy`` — APY of the underlying yield source
+            (decimal); optional, ``NaN`` when not exposed.
+        ``max_apy`` — upper-bound projected APY (decimal); optional,
+            ``NaN`` when not exposed.
     """
 
     def __init__(
         self,
-        pt_prices,
-        implied_yields,
-        seconds_to_expiry,
-        pool_liquidity,
-        time,
+        pt_prices: ArrayLike,
+        implied_yields: ArrayLike,
+        seconds_to_expiry: ArrayLike,
+        pool_liquidity: ArrayLike,
+        time: TimeLike,
+        base_apy: Optional[ArrayLike] = None,
+        underlying_apy: Optional[ArrayLike] = None,
+        max_apy: Optional[ArrayLike] = None,
     ):
+        pt = np.asarray(pt_prices, dtype=float)
+        n = len(pt)
+
+        def _opt(col: Optional[ArrayLike]) -> np.ndarray:
+            if col is None:
+                return np.full(n, np.nan, dtype=float)
+            return np.asarray(col, dtype=float)
+
         data = {
-            "pt_price": np.asarray(pt_prices, dtype=float),
+            "pt_price": pt,
             "implied_yield": np.asarray(implied_yields, dtype=float),
             "seconds_to_expiry": np.asarray(seconds_to_expiry, dtype=float),
             "pool_liquidity": np.asarray(pool_liquidity, dtype=float),
-        }
-        super().__init__(data=data, index=_to_utc_index(time))
-
-
-class MorphoMarketHistory(pd.DataFrame):
-    """Morpho Blue isolated-market historical state indexed by UTC time.
-
-    Columns:
-        ``borrowing_rate`` — annualised borrow APY (decimal,
-            ``0.05`` = 5% APY).
-        ``utilization`` — fraction of supplied debt currently
-            borrowed, in ``[0, 1]``.
-        ``supply_apy`` — annualised supply APY (decimal), exposed
-            for completeness; PT-collateral markets pay no supplier
-            yield, but other markets do.
-    """
-
-    def __init__(
-        self,
-        borrowing_rates,
-        utilization,
-        supply_apys,
-        time,
-    ):
-        data = {
-            "borrowing_rate": np.asarray(borrowing_rates, dtype=float),
-            "utilization": np.asarray(utilization, dtype=float),
-            "supply_apy": np.asarray(supply_apys, dtype=float),
+            "base_apy": _opt(base_apy),
+            "underlying_apy": _opt(underlying_apy),
+            "max_apy": _opt(max_apy),
         }
         super().__init__(data=data, index=_to_utc_index(time))
 
@@ -170,11 +194,11 @@ class BorosMarketHistory(pd.DataFrame):
 
     def __init__(
         self,
-        mark_apr,
-        observed_funding,
-        mark_apr_7d_ma,
-        mark_apr_30d_ma,
-        time,
+        mark_apr: ArrayLike,
+        observed_funding: ArrayLike,
+        mark_apr_7d_ma: ArrayLike,
+        mark_apr_30d_ma: ArrayLike,
+        time: TimeLike,
     ):
         data = {
             "mark_apr": np.asarray(mark_apr, dtype=float),

--- a/fractal/loaders/structs.py
+++ b/fractal/loaders/structs.py
@@ -98,6 +98,93 @@ class PoolHistory(pd.DataFrame):
 TrajectoryBundle = List[PriceHistory]
 
 
+class PendleMarketHistory(pd.DataFrame):
+    """Pendle Principal-Token market snapshots indexed by UTC time.
+
+    Columns:
+        ``pt_price`` — mark price of 1 PT in the underlying numeraire
+            (typically USDC).
+        ``implied_yield`` — annualised fixed yield encoded in
+            ``pt_price`` (decimal, ``0.14`` = 14% APY).
+        ``seconds_to_expiry`` — seconds remaining until PT redeem
+            unlocks.
+        ``pool_liquidity`` — total Pendle pool liquidity in numeraire.
+    """
+
+    def __init__(
+        self,
+        pt_prices,
+        implied_yields,
+        seconds_to_expiry,
+        pool_liquidity,
+        time,
+    ):
+        data = {
+            "pt_price": np.asarray(pt_prices, dtype=float),
+            "implied_yield": np.asarray(implied_yields, dtype=float),
+            "seconds_to_expiry": np.asarray(seconds_to_expiry, dtype=float),
+            "pool_liquidity": np.asarray(pool_liquidity, dtype=float),
+        }
+        super().__init__(data=data, index=_to_utc_index(time))
+
+
+class MorphoMarketHistory(pd.DataFrame):
+    """Morpho Blue isolated-market historical state indexed by UTC time.
+
+    Columns:
+        ``borrowing_rate`` — annualised borrow APY (decimal,
+            ``0.05`` = 5% APY).
+        ``utilization`` — fraction of supplied debt currently
+            borrowed, in ``[0, 1]``.
+        ``supply_apy`` — annualised supply APY (decimal), exposed
+            for completeness; PT-collateral markets pay no supplier
+            yield, but other markets do.
+    """
+
+    def __init__(
+        self,
+        borrowing_rates,
+        utilization,
+        supply_apys,
+        time,
+    ):
+        data = {
+            "borrowing_rate": np.asarray(borrowing_rates, dtype=float),
+            "utilization": np.asarray(utilization, dtype=float),
+            "supply_apy": np.asarray(supply_apys, dtype=float),
+        }
+        super().__init__(data=data, index=_to_utc_index(time))
+
+
+class BorosMarketHistory(pd.DataFrame):
+    """Pendle Boros funding-rate-forward market bars indexed by UTC time.
+
+    Columns:
+        ``mark_apr`` — close mark APR (annualised decimal). Long-Boros
+            holders receive this as funding per unit of time.
+        ``observed_funding`` — close observed funding rate
+            (annualised decimal).
+        ``mark_apr_7d_ma`` — 7-day moving average of observed funding.
+        ``mark_apr_30d_ma`` — 30-day moving average of observed funding.
+    """
+
+    def __init__(
+        self,
+        mark_apr,
+        observed_funding,
+        mark_apr_7d_ma,
+        mark_apr_30d_ma,
+        time,
+    ):
+        data = {
+            "mark_apr": np.asarray(mark_apr, dtype=float),
+            "observed_funding": np.asarray(observed_funding, dtype=float),
+            "mark_apr_7d_ma": np.asarray(mark_apr_7d_ma, dtype=float),
+            "mark_apr_30d_ma": np.asarray(mark_apr_30d_ma, dtype=float),
+        }
+        super().__init__(data=data, index=_to_utc_index(time))
+
+
 class KlinesHistory(pd.DataFrame):
     """
     OHLCV klines. Columns: ``open``, ``high``, ``low``, ``close``, ``volume``.

--- a/tests/core/test_funding_hedge.py
+++ b/tests/core/test_funding_hedge.py
@@ -1,0 +1,91 @@
+"""Offline tests for :class:`FundingHedgeEntity`.
+
+Cover the linear PnL accrual, the long/short sign flip, and the
+invariant that withdrawing notional does not unwind already-realised
+funding payments.
+"""
+import math
+
+import pytest
+
+from fractal.core.base.entity import EntityException
+from fractal.core.entities.protocols.funding_hedge import (
+    FundingHedgeConfig,
+    FundingHedgeEntity,
+    FundingHedgeGlobalState,
+)
+
+
+SECONDS_PER_YEAR = 365.25 * 24 * 3600
+
+
+@pytest.mark.core
+def test_first_update_seeds_timestamp_without_accrual():
+    e = FundingHedgeEntity()
+    e.action_deposit(10_000.0)
+    e.update_state(FundingHedgeGlobalState(funding_rate=0.10, timestamp_seconds=0.0))
+    assert e._internal_state.accrued_pnl == 0.0
+    assert e._internal_state.last_timestamp == 0.0
+
+
+@pytest.mark.core
+def test_one_hour_long_accrual_matches_closed_form():
+    e = FundingHedgeEntity()
+    e.action_deposit(10_000.0)
+    e.update_state(FundingHedgeGlobalState(funding_rate=0.10, timestamp_seconds=0.0))
+    e.update_state(FundingHedgeGlobalState(funding_rate=0.10, timestamp_seconds=3600.0))
+    expected = 10_000.0 * 0.10 * (3600.0 / SECONDS_PER_YEAR)
+    assert math.isclose(e._internal_state.accrued_pnl, expected, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_short_direction_flips_sign():
+    e = FundingHedgeEntity(FundingHedgeConfig(direction="short"))
+    e.action_deposit(10_000.0)
+    e.update_state(FundingHedgeGlobalState(funding_rate=0.10, timestamp_seconds=0.0))
+    e.update_state(FundingHedgeGlobalState(funding_rate=0.10, timestamp_seconds=3600.0))
+    expected = -10_000.0 * 0.10 * (3600.0 / SECONDS_PER_YEAR)
+    assert math.isclose(e._internal_state.accrued_pnl, expected, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_negative_funding_rate_loses_money():
+    e = FundingHedgeEntity()
+    e.action_deposit(10_000.0)
+    e.update_state(FundingHedgeGlobalState(funding_rate=-0.05, timestamp_seconds=0.0))
+    e.update_state(FundingHedgeGlobalState(funding_rate=-0.05, timestamp_seconds=3600.0))
+    assert e._internal_state.accrued_pnl < 0.0
+
+
+@pytest.mark.core
+def test_withdraw_keeps_realised_pnl():
+    e = FundingHedgeEntity()
+    e.action_deposit(10_000.0)
+    e.update_state(FundingHedgeGlobalState(funding_rate=0.10, timestamp_seconds=0.0))
+    e.update_state(FundingHedgeGlobalState(funding_rate=0.10, timestamp_seconds=3600.0))
+    pnl_before = e._internal_state.accrued_pnl
+    e.action_withdraw(10_000.0)
+    assert e._internal_state.notional == 0.0
+    assert e._internal_state.accrued_pnl == pnl_before
+
+
+@pytest.mark.core
+def test_action_deposit_rejects_negative():
+    e = FundingHedgeEntity()
+    with pytest.raises(EntityException):
+        e.action_deposit(-1.0)
+
+
+@pytest.mark.core
+def test_action_withdraw_rejects_oversize():
+    e = FundingHedgeEntity()
+    e.action_deposit(100.0)
+    with pytest.raises(EntityException):
+        e.action_withdraw(500.0)
+
+
+@pytest.mark.core
+def test_balance_equals_accrued_pnl():
+    e = FundingHedgeEntity()
+    e._internal_state.accrued_pnl = 123.45
+    assert e.balance == 123.45

--- a/tests/core/test_funding_hedge.py
+++ b/tests/core/test_funding_hedge.py
@@ -1,8 +1,8 @@
 """Offline tests for :class:`FundingHedgeEntity`.
 
-Cover the linear PnL accrual, the long/short sign flip, and the
-invariant that withdrawing notional does not unwind already-realised
-funding payments.
+Cover the linear PnL accrual, the long/short sign flip, the
+direction-config validation and the invariant that withdrawing
+notional does not unwind already-realised funding payments.
 """
 import math
 
@@ -89,3 +89,16 @@ def test_balance_equals_accrued_pnl():
     e = FundingHedgeEntity()
     e._internal_state.accrued_pnl = 123.45
     assert e.balance == 123.45
+
+
+@pytest.mark.core
+def test_config_rejects_unknown_direction():
+    """A typo in ``direction`` must raise at construction, not silently flip sign."""
+    with pytest.raises(EntityException):
+        FundingHedgeEntity(FundingHedgeConfig(direction="lng"))  # type: ignore[arg-type]
+
+
+@pytest.mark.core
+def test_config_rejects_uppercase_long():
+    with pytest.raises(EntityException):
+        FundingHedgeEntity(FundingHedgeConfig(direction="LONG"))  # type: ignore[arg-type]

--- a/tests/core/test_morpho.py
+++ b/tests/core/test_morpho.py
@@ -1,0 +1,114 @@
+"""Offline tests for :class:`MorphoEntity`.
+
+Cover the LLTV-bounded mutations, the borrow-rate accrual at hourly
+granularity, the latching liquidation flag and the derived health
+factor / LTV properties.
+"""
+import math
+
+import pytest
+
+from fractal.core.base.entity import EntityException
+from fractal.core.entities.protocols.morpho import (
+    MorphoConfig,
+    MorphoEntity,
+    MorphoGlobalState,
+)
+
+SECONDS_PER_YEAR = 365.25 * 24 * 3600
+
+
+def _make_market(lltv: float = 0.86) -> MorphoEntity:
+    return MorphoEntity(MorphoConfig(lltv=lltv))
+
+
+@pytest.mark.core
+def test_initial_ltv_is_zero_without_collateral_or_debt():
+    e = _make_market()
+    e.update_state(MorphoGlobalState(collateral_price=1.0, debt_price=1.0, timestamp_seconds=0.0))
+    assert e.ltv == 0.0
+    assert e.health_factor == float("inf")
+
+
+@pytest.mark.core
+def test_deposit_then_borrow_to_80_percent_ltv():
+    e = _make_market(lltv=0.86)
+    e.update_state(MorphoGlobalState(collateral_price=1.0, timestamp_seconds=0.0))
+    e.action_deposit(1000.0)
+    e.action_borrow(800.0)
+    assert math.isclose(e.ltv, 0.80, rel_tol=1e-9)
+    assert math.isclose(e.health_factor, 0.86 / 0.80, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_borrow_rejects_above_lltv():
+    e = _make_market(lltv=0.86)
+    e.update_state(MorphoGlobalState(collateral_price=1.0, timestamp_seconds=0.0))
+    e.action_deposit(1000.0)
+    with pytest.raises(EntityException):
+        e.action_borrow(900.0)  # 90% LTV > 86% LLTV
+    # Rollback: debt restored to zero, not 900.
+    assert e._internal_state.debt == 0.0
+
+
+@pytest.mark.core
+def test_withdraw_rejects_if_pushes_above_lltv():
+    e = _make_market(lltv=0.86)
+    e.update_state(MorphoGlobalState(collateral_price=1.0, timestamp_seconds=0.0))
+    e.action_deposit(1000.0)
+    e.action_borrow(800.0)
+    with pytest.raises(EntityException):
+        e.action_withdraw(100.0)  # debt 800 / collateral 900 = 88.9% > 86%
+    assert e._internal_state.collateral == 1000.0
+
+
+@pytest.mark.core
+def test_borrow_rate_accrues_over_one_hour():
+    e = _make_market()
+    e.update_state(MorphoGlobalState(collateral_price=1.0, borrowing_rate=0.10, timestamp_seconds=0.0))
+    e.action_deposit(1000.0)
+    e.action_borrow(500.0)
+    # Advance one hour; 10% APY on 500 USDC over 1h ≈ 500 * 0.10 / (365.25*24)
+    e.update_state(
+        MorphoGlobalState(
+            collateral_price=1.0,
+            borrowing_rate=0.10,
+            timestamp_seconds=3600.0,
+        )
+    )
+    expected = 500.0 * (1.0 + 0.10 / (365.25 * 24))
+    assert math.isclose(e._internal_state.debt, expected, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_collateral_price_drop_latches_liquidation_flag():
+    e = _make_market(lltv=0.86)
+    e.update_state(MorphoGlobalState(collateral_price=1.0, timestamp_seconds=0.0))
+    e.action_deposit(1000.0)
+    e.action_borrow(800.0)
+    # Collateral drops 20% -> position is now 800 / (1000 * 0.8) = 100% LTV
+    e.update_state(MorphoGlobalState(collateral_price=0.8, timestamp_seconds=3600.0))
+    assert e.is_liquidated
+    with pytest.raises(EntityException):
+        e.action_deposit(100.0)  # latched: no further actions allowed
+
+
+@pytest.mark.core
+def test_repay_more_than_outstanding_rejected():
+    e = _make_market()
+    e.update_state(MorphoGlobalState(collateral_price=1.0, timestamp_seconds=0.0))
+    e.action_deposit(1000.0)
+    e.action_borrow(500.0)
+    with pytest.raises(EntityException):
+        e.action_repay(600.0)
+    assert e._internal_state.debt == 500.0
+
+
+@pytest.mark.core
+def test_balance_is_collateral_minus_debt():
+    e = _make_market()
+    e.update_state(MorphoGlobalState(collateral_price=2.0, timestamp_seconds=0.0))
+    e.action_deposit(100.0)
+    e.action_borrow(50.0)
+    # collateral_value = 100 * 2 = 200; debt = 50; balance = 150.
+    assert math.isclose(e.balance, 150.0, rel_tol=1e-9)

--- a/tests/core/test_morpho.py
+++ b/tests/core/test_morpho.py
@@ -1,8 +1,9 @@
 """Offline tests for :class:`MorphoEntity`.
 
 Cover the LLTV-bounded mutations, the borrow-rate accrual at hourly
-granularity, the latching liquidation flag and the derived health
-factor / LTV properties.
+granularity, the latching liquidation flag, derived health-factor /
+LTV properties (including the insolvent inf branch) and the config
+validation on construction.
 """
 import math
 
@@ -46,8 +47,7 @@ def test_borrow_rejects_above_lltv():
     e.update_state(MorphoGlobalState(collateral_price=1.0, timestamp_seconds=0.0))
     e.action_deposit(1000.0)
     with pytest.raises(EntityException):
-        e.action_borrow(900.0)  # 90% LTV > 86% LLTV
-    # Rollback: debt restored to zero, not 900.
+        e.action_borrow(900.0)
     assert e._internal_state.debt == 0.0
 
 
@@ -58,7 +58,7 @@ def test_withdraw_rejects_if_pushes_above_lltv():
     e.action_deposit(1000.0)
     e.action_borrow(800.0)
     with pytest.raises(EntityException):
-        e.action_withdraw(100.0)  # debt 800 / collateral 900 = 88.9% > 86%
+        e.action_withdraw(100.0)
     assert e._internal_state.collateral == 1000.0
 
 
@@ -68,7 +68,6 @@ def test_borrow_rate_accrues_over_one_hour():
     e.update_state(MorphoGlobalState(collateral_price=1.0, borrowing_rate=0.10, timestamp_seconds=0.0))
     e.action_deposit(1000.0)
     e.action_borrow(500.0)
-    # Advance one hour; 10% APY on 500 USDC over 1h ≈ 500 * 0.10 / (365.25*24)
     e.update_state(
         MorphoGlobalState(
             collateral_price=1.0,
@@ -86,11 +85,10 @@ def test_collateral_price_drop_latches_liquidation_flag():
     e.update_state(MorphoGlobalState(collateral_price=1.0, timestamp_seconds=0.0))
     e.action_deposit(1000.0)
     e.action_borrow(800.0)
-    # Collateral drops 20% -> position is now 800 / (1000 * 0.8) = 100% LTV
     e.update_state(MorphoGlobalState(collateral_price=0.8, timestamp_seconds=3600.0))
     assert e.is_liquidated
     with pytest.raises(EntityException):
-        e.action_deposit(100.0)  # latched: no further actions allowed
+        e.action_deposit(100.0)
 
 
 @pytest.mark.core
@@ -110,5 +108,44 @@ def test_balance_is_collateral_minus_debt():
     e.update_state(MorphoGlobalState(collateral_price=2.0, timestamp_seconds=0.0))
     e.action_deposit(100.0)
     e.action_borrow(50.0)
-    # collateral_value = 100 * 2 = 200; debt = 50; balance = 150.
     assert math.isclose(e.balance, 150.0, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_ltv_is_inf_when_insolvent_no_collateral_with_debt():
+    """Collateral price → 0 with outstanding debt → ltv = +inf, latches liq."""
+    e = _make_market(lltv=0.86)
+    e.update_state(MorphoGlobalState(collateral_price=1.0, timestamp_seconds=0.0))
+    e.action_deposit(1000.0)
+    e.action_borrow(500.0)
+    # Total collateral wipe: positive debt, zero collateral_value → ltv inf.
+    e.update_state(MorphoGlobalState(collateral_price=0.0, timestamp_seconds=3600.0))
+    assert e.ltv == float("inf")
+    assert e.is_liquidated
+    # Latched: any further action must raise.
+    with pytest.raises(EntityException):
+        e.action_borrow(1.0)
+
+
+@pytest.mark.core
+def test_config_rejects_lltv_above_one():
+    with pytest.raises(EntityException):
+        MorphoEntity(MorphoConfig(lltv=1.5))
+
+
+@pytest.mark.core
+def test_config_rejects_lltv_at_zero():
+    with pytest.raises(EntityException):
+        MorphoEntity(MorphoConfig(lltv=0.0))
+
+
+@pytest.mark.core
+def test_config_rejects_negative_lltv():
+    with pytest.raises(EntityException):
+        MorphoEntity(MorphoConfig(lltv=-0.1))
+
+
+@pytest.mark.core
+def test_config_rejects_negative_liquidation_penalty():
+    with pytest.raises(EntityException):
+        MorphoEntity(MorphoConfig(lltv=0.86, liquidation_penalty=-0.01))

--- a/tests/core/test_pendle_pt.py
+++ b/tests/core/test_pendle_pt.py
@@ -1,7 +1,8 @@
 """Offline tests for :class:`PendlePTEntity`.
 
 Cover the swap fee + slippage math, the redeem invariants, the
-balance / mark-to-market identity and the depeg-aware redeem path.
+balance / mark-to-market identity (pre- and post-expiry, with and
+without underlying depeg) and the depeg-aware redeem path.
 """
 import math
 
@@ -45,10 +46,8 @@ def test_compute_pt_price_linear_matches_formula():
 
 @pytest.mark.core
 def test_compute_pt_price_clamped_to_unit_interval():
-    # 100% APY × 5 years would give negative price; must clamp.
     five_years = 5 * 365.25 * 24 * 3600
     assert compute_pt_price(1.0, five_years, "linear") == 0.0
-    # Negative implied yield (premium) would give > 1; must clamp.
     assert compute_pt_price(-0.10, 30 * 24 * 3600, "linear") == 1.0
 
 
@@ -64,8 +63,6 @@ def test_buy_pt_deducts_cash_and_adds_face():
     e.action_deposit(1000.0)
     e.action_buy_pt(1000.0)
     assert e._internal_state.cash == 0.0
-    # Without fee/slippage we would receive 1000/0.95; here both are tiny but
-    # non-zero so face received < that.
     assert 0.0 < e._internal_state.pt_face_amount < 1000.0 / 0.95
 
 
@@ -92,8 +89,6 @@ def test_sell_pt_round_trip_loses_to_fees():
     e.action_buy_pt(1000.0)
     face = e._internal_state.pt_face_amount
     e.action_sell_pt(face)
-    # Round-trip: fees both legs + size impact both directions; must end below
-    # the original 1000 USDC.
     assert e._internal_state.pt_face_amount == 0.0
     assert e._internal_state.cash < 1000.0
 
@@ -110,10 +105,9 @@ def test_redeem_requires_expired():
 def test_redeem_at_expiry_pays_face_in_usdc():
     e = _open_entity()
     e._internal_state.pt_face_amount = 100.0
-    # update_state with seconds_to_expiry <= 0 snaps pt_price to 1
     e.update_state(
         PendlePTGlobalState(
-            pt_price=0.5,  # caller-provided value is overridden
+            pt_price=0.5,  # caller value is overridden by update_state
             implied_yield=0.0,
             seconds_to_expiry=0.0,
             pool_liquidity=1_000_000.0,
@@ -135,7 +129,7 @@ def test_redeem_realises_underlying_depeg():
             implied_yield=0.0,
             seconds_to_expiry=0.0,
             pool_liquidity=1_000_000.0,
-            sy_price_in_usdc=0.97,  # 3% underlying depeg at expiry
+            sy_price_in_usdc=0.97,
         )
     )
     e.action_redeem(100.0)
@@ -143,8 +137,30 @@ def test_redeem_realises_underlying_depeg():
 
 
 @pytest.mark.core
-def test_balance_is_cash_plus_pt_marked_to_market():
+def test_balance_pre_expiry_uses_pt_price_only():
     e = _open_entity(pt_price=0.95)
     e._internal_state.cash = 200.0
     e._internal_state.pt_face_amount = 100.0
+    # Pre-expiry: sy_price_in_usdc is irrelevant.
     assert math.isclose(e.balance, 200.0 + 100.0 * 0.95, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_balance_post_expiry_marks_face_at_sy_price():
+    """Post-expiry NAV must reflect underlying depeg even before redeem."""
+    e = _open_entity()
+    e._internal_state.cash = 50.0
+    e._internal_state.pt_face_amount = 100.0
+    # Snap to expired with a 4% underlying depeg.
+    e.update_state(
+        PendlePTGlobalState(
+            pt_price=1.0,
+            implied_yield=0.0,
+            seconds_to_expiry=0.0,
+            pool_liquidity=1_000_000.0,
+            sy_price_in_usdc=0.96,
+        )
+    )
+    # Expected: cash + face * sy_price_in_usdc = 50 + 100*0.96 = 146.0,
+    # not 50 + 100*1.0 = 150.0 (the pre-fix overstatement).
+    assert math.isclose(e.balance, 146.0, rel_tol=1e-9)

--- a/tests/core/test_pendle_pt.py
+++ b/tests/core/test_pendle_pt.py
@@ -1,0 +1,150 @@
+"""Offline tests for :class:`PendlePTEntity`.
+
+Cover the swap fee + slippage math, the redeem invariants, the
+balance / mark-to-market identity and the depeg-aware redeem path.
+"""
+import math
+
+import pytest
+
+from fractal.core.base.entity import EntityException
+from fractal.core.entities.protocols.pendle_pt import (
+    PendlePTConfig,
+    PendlePTEntity,
+    PendlePTGlobalState,
+    compute_pt_price,
+)
+
+
+def _open_entity(pt_price: float = 0.95, pool: float = 1_000_000.0) -> PendlePTEntity:
+    e = PendlePTEntity(PendlePTConfig(amm_fee_rate=0.001, slippage_factor=0.5))
+    e.update_state(
+        PendlePTGlobalState(
+            pt_price=pt_price,
+            implied_yield=0.10,
+            seconds_to_expiry=30 * 24 * 3600,
+            pool_liquidity=pool,
+        )
+    )
+    return e
+
+
+@pytest.mark.core
+def test_compute_pt_price_at_expiry_is_unity():
+    assert compute_pt_price(0.14, 0.0) == 1.0
+    assert compute_pt_price(0.14, -100.0) == 1.0
+
+
+@pytest.mark.core
+def test_compute_pt_price_linear_matches_formula():
+    secs = 90 * 24 * 3600
+    tau = secs / (365.25 * 24 * 3600)
+    expected = 1.0 - 0.10 * tau
+    assert math.isclose(compute_pt_price(0.10, secs, "linear"), expected, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_compute_pt_price_clamped_to_unit_interval():
+    # 100% APY × 5 years would give negative price; must clamp.
+    five_years = 5 * 365.25 * 24 * 3600
+    assert compute_pt_price(1.0, five_years, "linear") == 0.0
+    # Negative implied yield (premium) would give > 1; must clamp.
+    assert compute_pt_price(-0.10, 30 * 24 * 3600, "linear") == 1.0
+
+
+@pytest.mark.core
+def test_compute_pt_price_unknown_mode_raises():
+    with pytest.raises(EntityException):
+        compute_pt_price(0.10, 1000.0, "log-curve")
+
+
+@pytest.mark.core
+def test_buy_pt_deducts_cash_and_adds_face():
+    e = _open_entity()
+    e.action_deposit(1000.0)
+    e.action_buy_pt(1000.0)
+    assert e._internal_state.cash == 0.0
+    # Without fee/slippage we would receive 1000/0.95; here both are tiny but
+    # non-zero so face received < that.
+    assert 0.0 < e._internal_state.pt_face_amount < 1000.0 / 0.95
+
+
+@pytest.mark.core
+def test_buy_pt_rejects_oversize_cash_draw():
+    e = _open_entity()
+    e.action_deposit(100.0)
+    with pytest.raises(EntityException):
+        e.action_buy_pt(1000.0)
+
+
+@pytest.mark.core
+def test_buy_pt_rejects_negative_amount():
+    e = _open_entity()
+    e.action_deposit(100.0)
+    with pytest.raises(EntityException):
+        e.action_buy_pt(-10.0)
+
+
+@pytest.mark.core
+def test_sell_pt_round_trip_loses_to_fees():
+    e = _open_entity()
+    e.action_deposit(1000.0)
+    e.action_buy_pt(1000.0)
+    face = e._internal_state.pt_face_amount
+    e.action_sell_pt(face)
+    # Round-trip: fees both legs + size impact both directions; must end below
+    # the original 1000 USDC.
+    assert e._internal_state.pt_face_amount == 0.0
+    assert e._internal_state.cash < 1000.0
+
+
+@pytest.mark.core
+def test_redeem_requires_expired():
+    e = _open_entity()
+    e._internal_state.pt_face_amount = 100.0
+    with pytest.raises(EntityException):
+        e.action_redeem(100.0)
+
+
+@pytest.mark.core
+def test_redeem_at_expiry_pays_face_in_usdc():
+    e = _open_entity()
+    e._internal_state.pt_face_amount = 100.0
+    # update_state with seconds_to_expiry <= 0 snaps pt_price to 1
+    e.update_state(
+        PendlePTGlobalState(
+            pt_price=0.5,  # caller-provided value is overridden
+            implied_yield=0.0,
+            seconds_to_expiry=0.0,
+            pool_liquidity=1_000_000.0,
+            sy_price_in_usdc=1.0,
+        )
+    )
+    e.action_redeem(100.0)
+    assert e._internal_state.pt_face_amount == 0.0
+    assert math.isclose(e._internal_state.cash, 100.0, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_redeem_realises_underlying_depeg():
+    e = _open_entity()
+    e._internal_state.pt_face_amount = 100.0
+    e.update_state(
+        PendlePTGlobalState(
+            pt_price=1.0,
+            implied_yield=0.0,
+            seconds_to_expiry=0.0,
+            pool_liquidity=1_000_000.0,
+            sy_price_in_usdc=0.97,  # 3% underlying depeg at expiry
+        )
+    )
+    e.action_redeem(100.0)
+    assert math.isclose(e._internal_state.cash, 97.0, rel_tol=1e-9)
+
+
+@pytest.mark.core
+def test_balance_is_cash_plus_pt_marked_to_market():
+    e = _open_entity(pt_price=0.95)
+    e._internal_state.cash = 200.0
+    e._internal_state.pt_face_amount = 100.0
+    assert math.isclose(e.balance, 200.0 + 100.0 * 0.95, rel_tol=1e-9)

--- a/tests/loaders/test_boros_loader_offline.py
+++ b/tests/loaders/test_boros_loader_offline.py
@@ -1,13 +1,15 @@
-"""Offline tests for ``BorosMarketLoader.transform()`` — no network.
+"""Offline tests for ``BorosMarketLoader`` — no network.
 
-Verify the bar-list parser, deduplication, malformed-row resilience,
-window clipping and typed-struct return contract.
+Cover the bar-list parser, deduplication, malformed-row resilience,
+window clipping, time-frame validation, the typed-struct contract on
+both cache paths, and the UTC-seconds index conversion.
 """
 from datetime import datetime, timezone
 
+import pandas as pd
 import pytest
 
-from fractal.loaders.boros import BorosMarketLoader
+from fractal.loaders.boros import BorosMarketLoader, _rebuild_from_cache
 from fractal.loaders.structs import BorosMarketHistory
 
 UTC = timezone.utc
@@ -28,6 +30,34 @@ def _bar(ts: int, mark: float) -> dict:
         "b7dmafr": mark,
         "b30dmafr": mark,
     }
+
+
+@pytest.mark.core
+def test_constructor_rejects_unknown_time_frame():
+    with pytest.raises(ValueError):
+        BorosMarketLoader(
+            market_id=74,
+            start_time=_START,
+            end_time=_END,
+            time_frame="1m",  # not in {5m, 1h, 1d, 1w}
+        )
+
+
+@pytest.mark.core
+def test_constructor_accepts_documented_time_frames():
+    for tf in ("5m", "1h", "1d", "1w"):
+        BorosMarketLoader(
+            market_id=74,
+            start_time=_START,
+            end_time=_END,
+            time_frame=tf,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_reversed_window():
+    with pytest.raises(ValueError):
+        BorosMarketLoader(market_id=74, start_time=_END, end_time=_START)
 
 
 @pytest.mark.core
@@ -56,6 +86,17 @@ def test_transform_returns_typed_struct():
 
 
 @pytest.mark.core
+def test_transform_index_is_utc_seconds_aware():
+    """Epoch seconds must land in the 2026 timeline, not near 1970."""
+    loader = _stub_loader()
+    ts_inside = int(_START.timestamp()) + 3600
+    loader._raw = {"results": [_bar(ts_inside, 0.03)]}
+    loader.transform()
+    assert loader._data.index[0].year == 2026
+    assert loader._data.index.tz is not None
+
+
+@pytest.mark.core
 def test_transform_clips_to_requested_window():
     loader = _stub_loader()
     ts_before = int(_START.timestamp()) - 86400
@@ -80,7 +121,6 @@ def test_transform_deduplicates_same_timestamp():
     loader._raw = {"results": [_bar(ts, 0.02), _bar(ts, 0.99)]}
     loader.transform()
     assert len(loader._data) == 1
-    # Keep first (0.02), drop second (0.99).
     assert loader._data["mark_apr"].iloc[0] == pytest.approx(0.02)
 
 
@@ -90,7 +130,7 @@ def test_transform_skips_malformed_rows():
     ts_ok = int(_START.timestamp()) + 3600
     loader._raw = {
         "results": [
-            {"ts": "not-an-int", "c": 0.01},  # malformed ts
+            {"ts": "not-an-int", "c": 0.01},
             _bar(ts_ok, 0.02),
         ]
     }
@@ -100,8 +140,46 @@ def test_transform_skips_malformed_rows():
 
 
 @pytest.mark.core
-def test_cache_key_is_deterministic():
-    a = _stub_loader()._cache_key()
-    b = _stub_loader()._cache_key()
-    assert a == b
-    assert "market74" in a
+def test_cache_key_uses_full_epoch_seconds():
+    """Different start times → different cache keys (no day-level collisions)."""
+    a = BorosMarketLoader(
+        market_id=74,
+        start_time=datetime(2026, 4, 23, 0, tzinfo=UTC),
+        end_time=datetime(2026, 4, 23, 6, tzinfo=UTC),
+    )
+    b = BorosMarketLoader(
+        market_id=74,
+        start_time=datetime(2026, 4, 23, 12, tzinfo=UTC),
+        end_time=datetime(2026, 4, 23, 18, tzinfo=UTC),
+    )
+    assert a._cache_key() != b._cache_key()
+    assert "market74" in a._cache_key()
+
+
+@pytest.mark.core
+def test_rebuild_from_cache_restores_typed_history():
+    df = pd.DataFrame(
+        {
+            "mark_apr": [0.03, 0.035],
+            "observed_funding": [0.03, 0.035],
+            "mark_apr_7d_ma": [0.029, 0.03],
+            "mark_apr_30d_ma": [0.028, 0.029],
+        },
+        index=pd.to_datetime(
+            [int(_START.timestamp()), int(_START.timestamp()) + 3600],
+            unit="s",
+            utc=True,
+        ),
+    )
+    df.index.name = "time"
+    rebuilt = _rebuild_from_cache(df)
+    assert isinstance(rebuilt, BorosMarketHistory)
+    assert rebuilt.index.tz is not None
+    assert len(rebuilt) == 2
+
+
+@pytest.mark.core
+def test_rebuild_from_cache_handles_empty_dataframe():
+    rebuilt = _rebuild_from_cache(pd.DataFrame())
+    assert isinstance(rebuilt, BorosMarketHistory)
+    assert rebuilt.empty

--- a/tests/loaders/test_boros_loader_offline.py
+++ b/tests/loaders/test_boros_loader_offline.py
@@ -1,0 +1,107 @@
+"""Offline tests for ``BorosMarketLoader.transform()`` — no network.
+
+Verify the bar-list parser, deduplication, malformed-row resilience,
+window clipping and typed-struct return contract.
+"""
+from datetime import datetime, timezone
+
+import pytest
+
+from fractal.loaders.boros import BorosMarketLoader
+from fractal.loaders.structs import BorosMarketHistory
+
+UTC = timezone.utc
+
+_START = datetime(2026, 4, 23, tzinfo=UTC)
+_END = datetime(2026, 5, 14, tzinfo=UTC)
+
+
+def _stub_loader() -> BorosMarketLoader:
+    return BorosMarketLoader(market_id=74, start_time=_START, end_time=_END)
+
+
+def _bar(ts: int, mark: float) -> dict:
+    return {
+        "ts": ts,
+        "c": mark,
+        "u": mark,
+        "b7dmafr": mark,
+        "b30dmafr": mark,
+    }
+
+
+@pytest.mark.core
+def test_transform_empty_payload():
+    loader = _stub_loader()
+    loader._raw = {}
+    loader.transform()
+    assert isinstance(loader._data, BorosMarketHistory)
+    assert loader._data.empty
+
+
+@pytest.mark.core
+def test_transform_returns_typed_struct():
+    loader = _stub_loader()
+    ts_inside = int(_START.timestamp()) + 3600
+    loader._raw = {"results": [_bar(ts_inside, 0.03)]}
+    loader.transform()
+    assert isinstance(loader._data, BorosMarketHistory)
+    assert list(loader._data.columns) == [
+        "mark_apr",
+        "observed_funding",
+        "mark_apr_7d_ma",
+        "mark_apr_30d_ma",
+    ]
+    assert len(loader._data) == 1
+
+
+@pytest.mark.core
+def test_transform_clips_to_requested_window():
+    loader = _stub_loader()
+    ts_before = int(_START.timestamp()) - 86400
+    ts_inside = int(_START.timestamp()) + 86400
+    ts_after = int(_END.timestamp()) + 86400
+    loader._raw = {
+        "results": [
+            _bar(ts_before, 0.01),
+            _bar(ts_inside, 0.02),
+            _bar(ts_after, 0.03),
+        ]
+    }
+    loader.transform()
+    assert len(loader._data) == 1
+    assert loader._data["mark_apr"].iloc[0] == pytest.approx(0.02)
+
+
+@pytest.mark.core
+def test_transform_deduplicates_same_timestamp():
+    loader = _stub_loader()
+    ts = int(_START.timestamp()) + 3600
+    loader._raw = {"results": [_bar(ts, 0.02), _bar(ts, 0.99)]}
+    loader.transform()
+    assert len(loader._data) == 1
+    # Keep first (0.02), drop second (0.99).
+    assert loader._data["mark_apr"].iloc[0] == pytest.approx(0.02)
+
+
+@pytest.mark.core
+def test_transform_skips_malformed_rows():
+    loader = _stub_loader()
+    ts_ok = int(_START.timestamp()) + 3600
+    loader._raw = {
+        "results": [
+            {"ts": "not-an-int", "c": 0.01},  # malformed ts
+            _bar(ts_ok, 0.02),
+        ]
+    }
+    loader.transform()
+    assert len(loader._data) == 1
+    assert loader._data["mark_apr"].iloc[0] == pytest.approx(0.02)
+
+
+@pytest.mark.core
+def test_cache_key_is_deterministic():
+    a = _stub_loader()._cache_key()
+    b = _stub_loader()._cache_key()
+    assert a == b
+    assert "market74" in a

--- a/tests/loaders/test_morpho_loader_offline.py
+++ b/tests/loaders/test_morpho_loader_offline.py
@@ -1,19 +1,20 @@
-"""Offline tests for ``MorphoMarketLoader.transform()`` — no network.
+"""Offline tests for ``MorphoMarketLoader`` — no network.
 
-Verify the GraphQL parallel-series merge, the empty-payload short-circuit
-and the typed-struct return contract.
+Verify the GraphQL parallel-series merge, the empty-payload short-circuit,
+the typed ``LendingHistory`` return contract (with ``utilization``), the
+strict 32-byte market-id validation, and the UTC-seconds index conversion.
 """
 from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
 
-from fractal.loaders.morpho import MorphoMarketLoader
-from fractal.loaders.structs import MorphoMarketHistory
+from fractal.loaders.morpho import MorphoMarketLoader, _rebuild_from_cache
+from fractal.loaders.structs import LendingHistory
 
 UTC = timezone.utc
 
-_STUB_MARKET = "0x" + "ab" * 32
+_STUB_MARKET = "0x" + "ab" * 32  # 32-byte = 64 hex chars after 0x
 _STUB_START = datetime(2025, 7, 27, tzinfo=UTC)
 _STUB_END = datetime(2025, 9, 25, tzinfo=UTC)
 
@@ -32,6 +33,31 @@ def test_constructor_validates_market_id_prefix():
     with pytest.raises(ValueError):
         MorphoMarketLoader(
             market_id="not-0x-prefixed",
+            chain="ethereum",
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_short_market_id():
+    """0x-prefix but only 4 hex chars: must fail (full 64-char check)."""
+    with pytest.raises(ValueError):
+        MorphoMarketLoader(
+            market_id="0xabcd",
+            chain="ethereum",
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_non_hex_market_id():
+    """0x + 64 chars but one of them is 'z': must fail."""
+    bad = "0x" + "z" * 64
+    with pytest.raises(ValueError):
+        MorphoMarketLoader(
+            market_id=bad,
             chain="ethereum",
             start_time=_STUB_START,
             end_time=_STUB_END,
@@ -61,21 +87,37 @@ def test_constructor_rejects_reversed_window():
 
 
 @pytest.mark.core
-def test_transform_returns_morpho_market_history():
+def test_transform_returns_lending_history():
     loader = _stub_loader()
-    # Staged frame as if `extract` had merged the three series.
     loader._data = pd.DataFrame(
         {
             "x": [int(_STUB_START.timestamp()), int(_STUB_END.timestamp())],
             "borrowing_rate": [0.05, 0.07],
             "utilization": [0.8, 0.9],
-            "supply_apy": [0.04, 0.06],
+            "lending_rate": [0.04, 0.06],
         }
     )
     loader.transform()
-    assert isinstance(loader._data, MorphoMarketHistory)
-    assert list(loader._data.columns) == ["borrowing_rate", "utilization", "supply_apy"]
+    assert isinstance(loader._data, LendingHistory)
+    assert list(loader._data.columns) == ["lending_rate", "borrowing_rate", "utilization"]
     assert len(loader._data) == 2
+
+
+@pytest.mark.core
+def test_transform_index_is_utc_seconds_aware():
+    """Epoch seconds must produce 2025 timestamps, not nanosecond offsets near 1970."""
+    loader = _stub_loader()
+    loader._data = pd.DataFrame(
+        {
+            "x": [int(_STUB_START.timestamp())],
+            "borrowing_rate": [0.05],
+            "utilization": [0.8],
+            "lending_rate": [0.04],
+        }
+    )
+    loader.transform()
+    assert loader._data.index[0].year == 2025
+    assert loader._data.index.tz is not None
 
 
 @pytest.mark.core
@@ -83,15 +125,58 @@ def test_transform_handles_empty_staging():
     loader = _stub_loader()
     loader._data = pd.DataFrame()
     loader.transform()
-    assert isinstance(loader._data, MorphoMarketHistory)
+    assert isinstance(loader._data, LendingHistory)
     assert loader._data.empty
 
 
 @pytest.mark.core
 def test_chain_id_routes_to_correct_network():
-    eth = _stub_loader("ethereum")
-    arb = _stub_loader("arbitrum")
-    base = _stub_loader("base")
-    assert eth._chain_id == 1
-    assert arb._chain_id == 42161
-    assert base._chain_id == 8453
+    assert _stub_loader("ethereum")._chain_id == 1
+    assert _stub_loader("arbitrum")._chain_id == 42161
+    assert _stub_loader("base")._chain_id == 8453
+
+
+@pytest.mark.core
+def test_cache_key_uses_epoch_seconds():
+    """Hour-different windows on the same day must produce different cache keys."""
+    a = MorphoMarketLoader(
+        market_id=_STUB_MARKET,
+        chain="ethereum",
+        start_time=datetime(2025, 7, 27, 0, tzinfo=UTC),
+        end_time=datetime(2025, 7, 27, 6, tzinfo=UTC),
+    )
+    b = MorphoMarketLoader(
+        market_id=_STUB_MARKET,
+        chain="ethereum",
+        start_time=datetime(2025, 7, 27, 12, tzinfo=UTC),
+        end_time=datetime(2025, 7, 27, 18, tzinfo=UTC),
+    )
+    assert a._cache_key() != b._cache_key()
+
+
+@pytest.mark.core
+def test_rebuild_from_cache_restores_typed_history():
+    df = pd.DataFrame(
+        {
+            "lending_rate": [0.04, 0.05],
+            "borrowing_rate": [0.05, 0.07],
+            "utilization": [0.8, 0.9],
+        },
+        index=pd.to_datetime(
+            [int(_STUB_START.timestamp()), int(_STUB_END.timestamp())],
+            unit="s",
+            utc=True,
+        ),
+    )
+    df.index.name = "time"
+    rebuilt = _rebuild_from_cache(df)
+    assert isinstance(rebuilt, LendingHistory)
+    assert rebuilt.index.tz is not None
+    assert len(rebuilt) == 2
+
+
+@pytest.mark.core
+def test_rebuild_from_cache_handles_empty_dataframe():
+    rebuilt = _rebuild_from_cache(pd.DataFrame())
+    assert isinstance(rebuilt, LendingHistory)
+    assert rebuilt.empty

--- a/tests/loaders/test_morpho_loader_offline.py
+++ b/tests/loaders/test_morpho_loader_offline.py
@@ -1,0 +1,97 @@
+"""Offline tests for ``MorphoMarketLoader.transform()`` — no network.
+
+Verify the GraphQL parallel-series merge, the empty-payload short-circuit
+and the typed-struct return contract.
+"""
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+from fractal.loaders.morpho import MorphoMarketLoader
+from fractal.loaders.structs import MorphoMarketHistory
+
+UTC = timezone.utc
+
+_STUB_MARKET = "0x" + "ab" * 32
+_STUB_START = datetime(2025, 7, 27, tzinfo=UTC)
+_STUB_END = datetime(2025, 9, 25, tzinfo=UTC)
+
+
+def _stub_loader(chain: str = "ethereum") -> MorphoMarketLoader:
+    return MorphoMarketLoader(
+        market_id=_STUB_MARKET,
+        chain=chain,
+        start_time=_STUB_START,
+        end_time=_STUB_END,
+    )
+
+
+@pytest.mark.core
+def test_constructor_validates_market_id_prefix():
+    with pytest.raises(ValueError):
+        MorphoMarketLoader(
+            market_id="not-0x-prefixed",
+            chain="ethereum",
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_unknown_chain():
+    with pytest.raises(ValueError):
+        MorphoMarketLoader(
+            market_id=_STUB_MARKET,
+            chain="solana",
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_reversed_window():
+    with pytest.raises(ValueError):
+        MorphoMarketLoader(
+            market_id=_STUB_MARKET,
+            chain="ethereum",
+            start_time=_STUB_END,
+            end_time=_STUB_START,
+        )
+
+
+@pytest.mark.core
+def test_transform_returns_morpho_market_history():
+    loader = _stub_loader()
+    # Staged frame as if `extract` had merged the three series.
+    loader._data = pd.DataFrame(
+        {
+            "x": [int(_STUB_START.timestamp()), int(_STUB_END.timestamp())],
+            "borrowing_rate": [0.05, 0.07],
+            "utilization": [0.8, 0.9],
+            "supply_apy": [0.04, 0.06],
+        }
+    )
+    loader.transform()
+    assert isinstance(loader._data, MorphoMarketHistory)
+    assert list(loader._data.columns) == ["borrowing_rate", "utilization", "supply_apy"]
+    assert len(loader._data) == 2
+
+
+@pytest.mark.core
+def test_transform_handles_empty_staging():
+    loader = _stub_loader()
+    loader._data = pd.DataFrame()
+    loader.transform()
+    assert isinstance(loader._data, MorphoMarketHistory)
+    assert loader._data.empty
+
+
+@pytest.mark.core
+def test_chain_id_routes_to_correct_network():
+    eth = _stub_loader("ethereum")
+    arb = _stub_loader("arbitrum")
+    base = _stub_loader("base")
+    assert eth._chain_id == 1
+    assert arb._chain_id == 42161
+    assert base._chain_id == 8453

--- a/tests/loaders/test_pendle_loader_offline.py
+++ b/tests/loaders/test_pendle_loader_offline.py
@@ -1,17 +1,25 @@
-"""Offline tests for ``PendleMarketLoader.transform()`` — no network.
+"""Offline tests for ``PendleMarketLoader`` — no network.
 
-Verify the linear PT-pricing convention and the parallel-array payload
-parsing against hand-crafted Pendle-style payloads.
+Verify the linear PT-pricing convention, the parallel-array payload
+parsing, the optional Pendle API fields (baseApy / underlyingApy /
+maxApy), the EVM-address validation on construction, the deterministic
+cache-key that includes hour-level epoch seconds, the typed-struct
+contract on both cache paths, and the UTC-seconds index conversion.
 """
 from datetime import datetime, timezone
 
+import pandas as pd
 import pytest
 
-from fractal.loaders.pendle import PendleMarketLoader, _compute_pt_price_linear
+from fractal.loaders.pendle import (
+    PendleMarketLoader,
+    _compute_pt_price_linear,
+    _rebuild_from_cache,
+)
+from fractal.loaders.structs import PendleMarketHistory
 
 UTC = timezone.utc
 
-# Stub market for constructor; transform() does not consult these.
 _STUB_MARKET = "0xa36b60a14a1a5247912584768c6e53e1a269a9f7"
 _STUB_EXPIRY = 1758758400  # 25 Sep 2025
 _STUB_START = datetime(2025, 7, 27, tzinfo=UTC)
@@ -57,8 +65,48 @@ def test_transform_returns_expected_columns():
         "tvl": [1_000_000.0, 1_100_000.0, 1_050_000.0],
     }
     loader.transform()
-    cols = set(loader._data.columns)
-    assert cols == {"pt_price", "implied_yield", "seconds_to_expiry", "pool_liquidity"}
+    expected = {
+        "pt_price",
+        "implied_yield",
+        "seconds_to_expiry",
+        "pool_liquidity",
+        "base_apy",
+        "underlying_apy",
+        "max_apy",
+    }
+    assert set(loader._data.columns) == expected
+    assert isinstance(loader._data, PendleMarketHistory)
+
+
+@pytest.mark.core
+def test_transform_unpacks_optional_api_fields():
+    loader = _stub_loader()
+    loader._raw = {
+        "timestamp": [_STUB_EXPIRY - 86400 * 2, _STUB_EXPIRY - 86400],
+        "impliedApy": [0.10, 0.11],
+        "tvl": [1.0e6, 1.1e6],
+        "baseApy": [0.07, 0.075],
+        "underlyingApy": [0.06, 0.065],
+        "maxApy": [0.20, 0.21],
+    }
+    loader.transform()
+    assert loader._data["base_apy"].iloc[0] == pytest.approx(0.07)
+    assert loader._data["underlying_apy"].iloc[1] == pytest.approx(0.065)
+    assert loader._data["max_apy"].iloc[1] == pytest.approx(0.21)
+
+
+@pytest.mark.core
+def test_transform_missing_optional_fields_yield_nan():
+    loader = _stub_loader()
+    loader._raw = {
+        "timestamp": [_STUB_EXPIRY - 86400],
+        "impliedApy": [0.10],
+        "tvl": [1.0e6],
+    }
+    loader.transform()
+    assert pd.isna(loader._data["base_apy"].iloc[0])
+    assert pd.isna(loader._data["underlying_apy"].iloc[0])
+    assert pd.isna(loader._data["max_apy"].iloc[0])
 
 
 @pytest.mark.core
@@ -75,10 +123,30 @@ def test_transform_seconds_to_expiry_strictly_decreasing():
 
 
 @pytest.mark.core
+def test_transform_index_is_utc_seconds_aware():
+    """Epoch seconds must land in the 2025 timeline, not near 1970."""
+    loader = _stub_loader()
+    loader._raw = {
+        "timestamp": [_STUB_EXPIRY - 86400],
+        "impliedApy": [0.10],
+        "tvl": [1.0e6],
+    }
+    loader.transform()
+    idx = loader._data.index
+    assert isinstance(idx, pd.DatetimeIndex)
+    assert idx.tz is not None  # tz-aware
+    # 2025-09-24
+    assert idx[0].year == 2025
+    assert idx[0].month == 9
+    assert idx[0].day == 24
+
+
+@pytest.mark.core
 def test_transform_handles_empty_payload():
     loader = _stub_loader()
     loader._raw = {}
     loader.transform()
+    assert isinstance(loader._data, PendleMarketHistory)
     assert loader._data.empty
 
 
@@ -91,5 +159,129 @@ def test_transform_skips_malformed_rows():
         "tvl": [1_000.0, 1_100.0, 1_050.0],
     }
     loader.transform()
-    # 3 input rows, 1 malformed; 2 valid output rows.
     assert len(loader._data) == 2
+
+
+@pytest.mark.core
+def test_constructor_rejects_invalid_market_address():
+    with pytest.raises(Exception):  # GraphLoaderException
+        PendleMarketLoader(
+            market_address="not-an-address",
+            expiry_timestamp=_STUB_EXPIRY,
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_path_traversal_in_address():
+    """Cache filename safety: reject anything that would escape the cache dir."""
+    with pytest.raises(Exception):
+        PendleMarketLoader(
+            market_address="0x../etc/passwd",
+            expiry_timestamp=_STUB_EXPIRY,
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_unsupported_chain():
+    with pytest.raises(ValueError):
+        PendleMarketLoader(
+            market_address=_STUB_MARKET,
+            expiry_timestamp=_STUB_EXPIRY,
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+            chain_id=10,  # Optimism not supported
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_reversed_window():
+    with pytest.raises(ValueError):
+        PendleMarketLoader(
+            market_address=_STUB_MARKET,
+            expiry_timestamp=_STUB_EXPIRY,
+            start_time=_STUB_END,
+            end_time=_STUB_START,
+        )
+
+
+@pytest.mark.core
+def test_cache_key_uses_full_epoch_seconds_not_dates():
+    """Two windows that share the date but differ by hours must not collide."""
+    a = PendleMarketLoader(
+        market_address=_STUB_MARKET,
+        expiry_timestamp=_STUB_EXPIRY,
+        start_time=datetime(2025, 7, 27, 0, tzinfo=UTC),
+        end_time=datetime(2025, 7, 27, 6, tzinfo=UTC),
+    )
+    b = PendleMarketLoader(
+        market_address=_STUB_MARKET,
+        expiry_timestamp=_STUB_EXPIRY,
+        start_time=datetime(2025, 7, 27, 12, tzinfo=UTC),
+        end_time=datetime(2025, 7, 27, 18, tzinfo=UTC),
+    )
+    assert a._cache_key() != b._cache_key()
+
+
+@pytest.mark.core
+def test_rebuild_from_cache_restores_typed_history():
+    """Cache rehydration must return ``PendleMarketHistory`` with UTC index."""
+    df = pd.DataFrame(
+        {
+            "pt_price": [0.98, 0.99],
+            "implied_yield": [0.10, 0.09],
+            "seconds_to_expiry": [3600.0, 1800.0],
+            "pool_liquidity": [1e6, 1e6],
+            "base_apy": [0.07, 0.07],
+            "underlying_apy": [0.06, 0.06],
+            "max_apy": [0.20, 0.20],
+        },
+        index=pd.to_datetime([_STUB_EXPIRY - 3600, _STUB_EXPIRY - 1800], unit="s", utc=True),
+    )
+    df.index.name = "time"
+    rebuilt = _rebuild_from_cache(df)
+    assert isinstance(rebuilt, PendleMarketHistory)
+    assert rebuilt.index.tz is not None
+    assert len(rebuilt) == 2
+
+
+@pytest.mark.core
+def test_rebuild_from_cache_handles_empty_dataframe():
+    rebuilt = _rebuild_from_cache(pd.DataFrame())
+    assert isinstance(rebuilt, PendleMarketHistory)
+    assert rebuilt.empty
+
+
+@pytest.mark.core
+def test_empty_history_constructor_accepts_required_and_optional_args():
+    """Regression guard: the empty-payload helper must construct a valid
+    ``PendleMarketHistory`` without ``TypeError``. The 5 required
+    parameters (``pt_prices``, ``implied_yields``, ``seconds_to_expiry``,
+    ``pool_liquidity``, ``time``) plus the 3 optional API-extra columns
+    are all explicit keyword arguments, so adding new optional columns
+    later does not silently change empty-branch behaviour.
+    """
+    h = PendleMarketHistory(
+        pt_prices=[],
+        implied_yields=[],
+        seconds_to_expiry=[],
+        pool_liquidity=[],
+        time=[],
+        base_apy=[],
+        underlying_apy=[],
+        max_apy=[],
+    )
+    assert isinstance(h, PendleMarketHistory)
+    assert h.empty
+    assert set(h.columns) >= {
+        "pt_price",
+        "implied_yield",
+        "seconds_to_expiry",
+        "pool_liquidity",
+        "base_apy",
+        "underlying_apy",
+        "max_apy",
+    }

--- a/tests/loaders/test_pendle_loader_offline.py
+++ b/tests/loaders/test_pendle_loader_offline.py
@@ -1,0 +1,95 @@
+"""Offline tests for ``PendleMarketLoader.transform()`` — no network.
+
+Verify the linear PT-pricing convention and the parallel-array payload
+parsing against hand-crafted Pendle-style payloads.
+"""
+from datetime import datetime, timezone
+
+import pytest
+
+from fractal.loaders.pendle import PendleMarketLoader, _compute_pt_price_linear
+
+UTC = timezone.utc
+
+# Stub market for constructor; transform() does not consult these.
+_STUB_MARKET = "0xa36b60a14a1a5247912584768c6e53e1a269a9f7"
+_STUB_EXPIRY = 1758758400  # 25 Sep 2025
+_STUB_START = datetime(2025, 7, 27, tzinfo=UTC)
+_STUB_END = datetime(2025, 9, 25, tzinfo=UTC)
+
+
+def _stub_loader() -> PendleMarketLoader:
+    return PendleMarketLoader(
+        market_address=_STUB_MARKET,
+        expiry_timestamp=_STUB_EXPIRY,
+        start_time=_STUB_START,
+        end_time=_STUB_END,
+    )
+
+
+@pytest.mark.core
+def test_compute_pt_price_linear_at_expiry_is_one():
+    assert _compute_pt_price_linear(0.14, 0.0) == 1.0
+    assert _compute_pt_price_linear(0.14, -100.0) == 1.0
+
+
+@pytest.mark.core
+def test_compute_pt_price_linear_matches_formula():
+    secs = 90 * 24 * 3600
+    tau = secs / (365.25 * 24 * 3600)
+    expected = 1.0 - 0.10 * tau
+    assert abs(_compute_pt_price_linear(0.10, secs) - expected) < 1e-12
+
+
+@pytest.mark.core
+def test_compute_pt_price_clamps_to_unit_interval():
+    five_years = 5 * 365.25 * 24 * 3600
+    assert _compute_pt_price_linear(1.0, five_years) == 0.0
+    assert _compute_pt_price_linear(-0.10, 30 * 24 * 3600) == 1.0
+
+
+@pytest.mark.core
+def test_transform_returns_expected_columns():
+    loader = _stub_loader()
+    loader._raw = {
+        "timestamp": [_STUB_EXPIRY - 86400 * i for i in range(3, 0, -1)],
+        "impliedApy": [0.12, 0.13, 0.14],
+        "tvl": [1_000_000.0, 1_100_000.0, 1_050_000.0],
+    }
+    loader.transform()
+    cols = set(loader._data.columns)
+    assert cols == {"pt_price", "implied_yield", "seconds_to_expiry", "pool_liquidity"}
+
+
+@pytest.mark.core
+def test_transform_seconds_to_expiry_strictly_decreasing():
+    loader = _stub_loader()
+    loader._raw = {
+        "timestamp": [_STUB_EXPIRY - 86400 * i for i in range(3, 0, -1)],
+        "impliedApy": [0.12, 0.13, 0.14],
+        "tvl": [1_000_000.0, 1_100_000.0, 1_050_000.0],
+    }
+    loader.transform()
+    secs = loader._data["seconds_to_expiry"].to_numpy()
+    assert (secs[:-1] > secs[1:]).all()
+
+
+@pytest.mark.core
+def test_transform_handles_empty_payload():
+    loader = _stub_loader()
+    loader._raw = {}
+    loader.transform()
+    assert loader._data.empty
+
+
+@pytest.mark.core
+def test_transform_skips_malformed_rows():
+    loader = _stub_loader()
+    loader._raw = {
+        "timestamp": [_STUB_EXPIRY - 7200, "not-a-number", _STUB_EXPIRY - 3600],
+        "impliedApy": [0.10, 0.12, 0.11],
+        "tvl": [1_000.0, 1_100.0, 1_050.0],
+    }
+    loader.transform()
+    # 3 input rows, 1 malformed; 2 valid output rows.
+    assert len(loader._data) == 2

--- a/tests/loaders/test_pendle_ohlcv_loader_offline.py
+++ b/tests/loaders/test_pendle_ohlcv_loader_offline.py
@@ -1,0 +1,213 @@
+"""Offline tests for ``PendleOHLCVLoader`` — no network.
+
+Verify the OHLCV bar parser against both response shapes Pendle has
+shipped in production (top-level list and ``{"results": [...]}``
+wrapper), the constructor validations (EVM address, chain id, time
+frame, window order), the deterministic cache key, the typed
+``KlinesHistory`` contract on both cache paths and the UTC-seconds
+index conversion.
+"""
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+from fractal.loaders.pendle_ohlcv import (
+    PendleOHLCVLoader,
+    _extract_bars,
+    _rebuild_from_cache,
+)
+from fractal.loaders.structs import KlinesHistory
+
+UTC = timezone.utc
+
+_STUB_TOKEN = "0x" + "ab" * 20
+_STUB_START = datetime(2025, 7, 27, tzinfo=UTC)
+_STUB_END = datetime(2025, 9, 25, tzinfo=UTC)
+
+
+def _stub_loader(**kw) -> PendleOHLCVLoader:
+    defaults = dict(
+        token_address=_STUB_TOKEN,
+        start_time=_STUB_START,
+        end_time=_STUB_END,
+    )
+    defaults.update(kw)
+    return PendleOHLCVLoader(**defaults)
+
+
+def _bar(t: int, c: float) -> dict:
+    return {
+        "time": t,
+        "open": c - 0.01,
+        "high": c + 0.01,
+        "low": c - 0.02,
+        "close": c,
+        "volume": 100.0,
+    }
+
+
+@pytest.mark.core
+def test_constructor_rejects_invalid_token_address():
+    with pytest.raises(Exception):
+        PendleOHLCVLoader(
+            token_address="not-an-address",
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_unsupported_chain():
+    with pytest.raises(ValueError):
+        PendleOHLCVLoader(
+            token_address=_STUB_TOKEN,
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+            chain_id=10,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_unknown_time_frame():
+    with pytest.raises(ValueError):
+        PendleOHLCVLoader(
+            token_address=_STUB_TOKEN,
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+            time_frame="2h",
+        )
+
+
+@pytest.mark.core
+def test_constructor_accepts_all_documented_time_frames():
+    for tf in ("1m", "5m", "15m", "1h", "4h", "1d", "1w"):
+        PendleOHLCVLoader(
+            token_address=_STUB_TOKEN,
+            start_time=_STUB_START,
+            end_time=_STUB_END,
+            time_frame=tf,
+        )
+
+
+@pytest.mark.core
+def test_constructor_rejects_reversed_window():
+    with pytest.raises(ValueError):
+        PendleOHLCVLoader(
+            token_address=_STUB_TOKEN,
+            start_time=_STUB_END,
+            end_time=_STUB_START,
+        )
+
+
+@pytest.mark.core
+def test_extract_bars_handles_top_level_list():
+    raw = [_bar(int(_STUB_START.timestamp()), 0.95)]
+    assert len(_extract_bars(raw)) == 1
+
+
+@pytest.mark.core
+def test_extract_bars_handles_wrapped_dict():
+    raw = {"results": [_bar(int(_STUB_START.timestamp()), 0.95)]}
+    assert len(_extract_bars(raw)) == 1
+    raw = {"data": [_bar(int(_STUB_START.timestamp()), 0.95)]}
+    assert len(_extract_bars(raw)) == 1
+
+
+@pytest.mark.core
+def test_extract_bars_handles_empty_payload():
+    assert _extract_bars(None) == []
+    assert _extract_bars({}) == []
+    assert _extract_bars([]) == []
+
+
+@pytest.mark.core
+def test_transform_returns_klines_history():
+    loader = _stub_loader()
+    t0 = int(_STUB_START.timestamp())
+    loader._raw = [
+        _bar(t0, 0.95),
+        _bar(t0 + 3600, 0.955),
+        _bar(t0 + 7200, 0.96),
+    ]
+    loader.transform()
+    assert isinstance(loader._data, KlinesHistory)
+    assert list(loader._data.columns) == ["open", "high", "low", "close", "volume"]
+    assert len(loader._data) == 3
+
+
+@pytest.mark.core
+def test_transform_index_is_utc_seconds_aware():
+    """Epoch seconds must produce 2025 timestamps, not nanosecond offsets."""
+    loader = _stub_loader()
+    loader._raw = [_bar(int(_STUB_START.timestamp()), 0.95)]
+    loader.transform()
+    assert loader._data.index[0].year == 2025
+    assert loader._data.index.tz is not None
+
+
+@pytest.mark.core
+def test_transform_empty_payload():
+    loader = _stub_loader()
+    loader._raw = []
+    loader.transform()
+    assert isinstance(loader._data, KlinesHistory)
+    assert loader._data.empty
+
+
+@pytest.mark.core
+def test_transform_skips_malformed_rows():
+    loader = _stub_loader()
+    t0 = int(_STUB_START.timestamp())
+    loader._raw = [
+        {"time": "not-a-number", "close": 0.95},
+        _bar(t0, 0.96),
+    ]
+    loader.transform()
+    assert len(loader._data) == 1
+    assert loader._data["close"].iloc[0] == pytest.approx(0.96)
+
+
+@pytest.mark.core
+def test_cache_key_uses_full_epoch_seconds():
+    a = PendleOHLCVLoader(
+        token_address=_STUB_TOKEN,
+        start_time=datetime(2025, 7, 27, 0, tzinfo=UTC),
+        end_time=datetime(2025, 7, 27, 6, tzinfo=UTC),
+    )
+    b = PendleOHLCVLoader(
+        token_address=_STUB_TOKEN,
+        start_time=datetime(2025, 7, 27, 12, tzinfo=UTC),
+        end_time=datetime(2025, 7, 27, 18, tzinfo=UTC),
+    )
+    assert a._cache_key() != b._cache_key()
+
+
+@pytest.mark.core
+def test_rebuild_from_cache_restores_typed_history():
+    df = pd.DataFrame(
+        {
+            "open": [0.95, 0.96],
+            "high": [0.96, 0.97],
+            "low": [0.94, 0.95],
+            "close": [0.955, 0.965],
+            "volume": [100.0, 110.0],
+        },
+        index=pd.to_datetime(
+            [int(_STUB_START.timestamp()), int(_STUB_START.timestamp()) + 3600],
+            unit="s",
+            utc=True,
+        ),
+    )
+    df.index.name = "time"
+    rebuilt = _rebuild_from_cache(df)
+    assert isinstance(rebuilt, KlinesHistory)
+    assert rebuilt.index.tz is not None
+    assert len(rebuilt) == 2
+
+
+@pytest.mark.core
+def test_rebuild_from_cache_handles_empty_dataframe():
+    rebuilt = _rebuild_from_cache(pd.DataFrame())
+    assert isinstance(rebuilt, KlinesHistory)
+    assert rebuilt.empty


### PR DESCRIPTION
## Summary

Adds first-class primitives for fixed-yield leveraged carry strategies
on the Pendle / Morpho / Boros stack:

- **3 new protocol entities** under `fractal.core.entities.protocols`:
  `PendlePTEntity`, `MorphoEntity`, `FundingHedgeEntity`.
- **3 new historical-data loaders** under `fractal.loaders`:
  `PendleMarketLoader`, `MorphoMarketLoader`, `BorosMarketLoader`.
- **3 new typed structs** under `fractal.loaders.structs`:
  `PendleMarketHistory`, `MorphoMarketHistory`, `BorosMarketHistory`.
- **47 new offline pytest cases** under ``@pytest.mark.core``
  (no network).

This **supersedes the loader-only PR** (`feat/pendle-market-loader`)
by shipping the full carry-loop stack alongside the loader trio.
Close that PR if you merge this one.

## Why

Pendle PT and Morpho Blue together form the dominant fixed-yield
carry primitive in DeFi (~$8B TVL across Ethereum / Arbitrum / Base),
and Boros adds a tokenised funding-rate forward layer on top of
Hyperliquid. Strategy authors who wanted to backtest carry / loop /
hedged-loop variants on this stack previously had to write every
entity and loader from scratch. This PR upstreams a clean, tested,
fractal-defi-native version.

## Entities

| Entity | Mechanic | Notable design points |
|---|---|---|
| `PendlePTEntity` | PT discount bond on Pendle AMM | linear `pt = 1 - y·τ` pricing matches Morpho's PT oracle on-chain; `sy_price_in_usdc < 1` at redeem captures underlying depeg correctly |
| `MorphoEntity` | Morpho Blue isolated market | extends `BaseLendingEntity`; post-mutation LLTV guard with atomic rollback on `action_borrow` / `action_withdraw`; latching `is_liquidated` flag |
| `FundingHedgeEntity` | abstract funding-rate carry leg | linear PnL accrual `s · notional · r_f · dt`, `s ∈ {±1}` via direction config |

## Loaders

| Loader | Endpoint | Auth | Returns |
|---|---|---|---|
| `PendleMarketLoader` | `api-v2.pendle.finance/core/v1/{chain_id}/markets/{addr}/historical-data` | none | `PendleMarketHistory` (4 cols) |
| `MorphoMarketLoader` | `blue-api.morpho.org/graphql` | none | `MorphoMarketHistory` (3 cols) |
| `BorosMarketLoader` | `api.boros.finance/core/v1/markets/chart` | none | `BorosMarketHistory` (4 cols) |

Chains supported by the Morpho loader: `ethereum` (1), `arbitrum`
(42161), `base` (8453).

## PT pricing convention

Pendle's REST does not expose a mid-price field, so the loader
reconstructs PT mark from `impliedApy`:

```
pt_price = 1 - implied_yield · tau,    clamped to [0, 1]
tau      = seconds_to_expiry / (365.25 · 86400)
```

This matches the linear approximation Morpho's PT oracle uses
on-chain, which keeps pricing consistent across the lending / Pendle
stack downstream consumers usually compose.

## Tests

47 new test cases across 6 modules, all ``@pytest.mark.core`` and no
network access. Total runtime ~0.4 s.

**Entities** (3 modules, 27 cases):

- `test_pendle_pt.py` (11): closed-form PT price (linear, clamp,
  expiry), buy/sell with fee + slippage, round-trip slippage cost,
  redeem pre-expiry rejection, redeem-at-expiry pays face, redeem
  realises underlying depeg via `sy_price_in_usdc`, balance identity.
- `test_morpho.py` (8): zero-state LTV, borrow to LLTV, borrow
  rejection above LLTV with rollback, withdraw rejection if pushes
  above LLTV, one-hour accrual closed-form, latching liquidation
  flag on collateral drop, repay-exceeds-debt rejection, balance
  identity.
- `test_funding_hedge.py` (8): first-update timestamp seeding,
  one-hour long accrual closed-form, short-direction sign flip,
  negative funding loses money, withdraw keeps realised PnL,
  negative-amount rejection, oversize-withdraw rejection,
  balance == accrued_pnl identity.

**Loaders** (3 modules, 20 cases):

- `test_pendle_loader_offline.py` (7): PT price linear/expiry/clamp,
  schema, monotonic `seconds_to_expiry`, empty short-circuit,
  malformed-row resilience.
- `test_morpho_loader_offline.py` (6): market-id 0x-prefix
  validation, unknown chain rejection, reversed window rejection,
  staged-frame → typed struct conversion, empty short-circuit,
  chain-id routing.
- `test_boros_loader_offline.py` (6): empty payload, typed-struct
  contract, window clipping, dedup on duplicate timestamps,
  malformed-row resilience, deterministic cache key.

## Out of scope

- **Pendle pagination** for windows larger than the endpoint's native
  ~60-day cap — downstream consumers currently stitch multiple loader
  instances. Drop-in upgrade when a concrete multi-cycle use case
  arrives upstream.
- **Boros long history** — endpoint is recent-only by design; the
  loader documents this rather than papering over it. Long-history
  backtests should compose with a Hyperliquid funding-rate proxy on
  the overlap window for calibration.
- **Strategies** themselves — kept in the consumer repo; only the
  primitives belong upstream.

## Context

Developed and dog-fooded as part of a Pendle PT carry-loop research
project. The downstream project has run six historical cycles across
Ethereum / Arbitrum / Base with realistic gas, bootstrap CI, vol
stress and an out-of-sample test on this stack. Stable enough that
pulling it upstream lets other users skip the bootstrap step.